### PR TITLE
feat(garden): automated irrigation system with mode profiles

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -24,6 +24,7 @@ homeassistant:
     terrace: !include packages/areas/outdoor/terrace/config.yaml
     garage: !include packages/areas/outdoor/garage/config.yaml
     gate: !include packages/areas/outdoor/gate/config.yaml
+    garden: !include packages/areas/outdoor/garden/config.yaml
     presence: !include packages/presence/config.yaml
     misc: !include packages/misc/config.yaml
     homekit: !include packages/homekit/config.yaml

--- a/docs/superpowers/plans/2026-04-10-garden-irrigation.md
+++ b/docs/superpowers/plans/2026-04-10-garden-irrigation.md
@@ -1,0 +1,633 @@
+# Garden Irrigation Automation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automated irrigation system with mode-driven profiles, weather-aware skip logic, auto-off valve control, HomeKit integration, and sequential scripting for a 4-zone Tuya sprinkler in Poland.
+
+**Architecture:** Auto-off automation is the single source of truth for valve durations. Scripts are pure sequencers that open valves and wait for them to close. A profile template sensor maps modes to durations/days. A skip logic binary sensor gates scheduled runs based on rain and season.
+
+**Tech Stack:** Home Assistant YAML packages, Jinja2 templates, Tuya Local valves, HomeKit integration, Met.no weather
+
+**Spec:** `docs/superpowers/specs/2026-04-10-garden-irrigation-design.md`
+
+---
+
+### Task 1: Create area package skeleton and config
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/config.yaml`
+- Create: `packages/areas/outdoor/garden/automations/` (directory)
+- Create: `packages/areas/outdoor/garden/scripts/` (directory)
+- Create: `packages/areas/outdoor/garden/templates/` (directory)
+- Modify: `configuration.yaml:26` (add garden package include)
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p packages/areas/outdoor/garden/{automations,scripts,templates}
+```
+
+- [ ] **Step 2: Create config.yaml**
+
+Create `packages/areas/outdoor/garden/config.yaml`:
+
+```yaml
+---
+automation: !include_dir_list automations
+template: !include_dir_list templates
+script: !include_dir_merge_named scripts
+
+input_select:
+  garden_irrigation_mode:
+    name: Garden Irrigation Mode
+    options:
+      - Eco
+      - Standard
+      - Intensive
+      - Smart
+    icon: mdi:sprinkler
+```
+
+Note: `!include_dir_merge_named` is used for scripts because each script file defines a named script (key: value), unlike automations/templates which use list format.
+
+- [ ] **Step 3: Add garden package to configuration.yaml**
+
+In `configuration.yaml`, add after the `gate` line (line 26):
+
+```yaml
+    garden: !include packages/areas/outdoor/garden/config.yaml
+```
+
+- [ ] **Step 4: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/config.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/config.yaml configuration.yaml
+git commit -m "feat(garden): add irrigation area package skeleton with input_select"
+```
+
+---
+
+### Task 2: Create skip logic template sensor
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml`
+
+- [ ] **Step 1: Create the skip logic binary sensor**
+
+Create `packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml`:
+
+```yaml
+---
+# Garden Should Skip Irrigation
+#
+# Returns 'on' when irrigation should be SKIPPED.
+# Checks: season (May-Sep only), current rain, rain forecast (6h lookahead).
+# Future: add soil moisture check when sensor is available.
+binary_sensor:
+  - name: Garden Should Skip Irrigation
+    unique_id: garden_should_skip_irrigation
+    icon: mdi:water-off
+    state: >
+      {% set is_raining = is_state('binary_sensor.raining', 'on') %}
+      {% set month = now().month %}
+      {% set in_season = month >= 5 and month <= 9 %}
+      {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+      {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
+      {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+      {% set rain_forecast = forecast
+          | selectattr('datetime', 'le', cutoff)
+          | selectattr('condition', 'in', rain_conditions)
+          | list
+          | count > 0 %}
+      {{ is_raining or rain_forecast or not in_season }}
+    attributes:
+      reason: >
+        {% set month = now().month %}
+        {% set in_season = month >= 5 and month <= 9 %}
+        {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+        {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
+        {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+        {% if not in_season %}
+          out_of_season
+        {% elif is_state('binary_sensor.raining', 'on') %}
+          raining_now
+        {% elif forecast
+            | selectattr('datetime', 'le', cutoff)
+            | selectattr('condition', 'in', rain_conditions)
+            | list
+            | count > 0 %}
+          rain_forecast_within_6h
+        {% else %}
+          none
+        {% endif %}
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+git commit -m "feat(garden): add skip logic binary sensor with rain and season checks"
+```
+
+---
+
+### Task 3: Create irrigation profile template sensor
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml`
+
+- [ ] **Step 1: Create the profile sensor**
+
+Create `packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml`:
+
+```yaml
+---
+# Garden Irrigation Profile
+#
+# Maps the selected irrigation mode to durations (minutes) and schedule days.
+# The 'profiles' attribute is a dictionary — the single source of truth
+# for all non-Smart mode parameters.
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ HOW TO ADD A NEW MODE                                              │
+# │                                                                    │
+# │ 1. Add an entry to the 'profiles' dict below with:                │
+# │    - lawn_duration: minutes per lawn zone                          │
+# │    - drip_duration: minutes for drip irrigation                    │
+# │    - lawn_days: list of ISO weekdays (1=Mon, 7=Sun)                │
+# │    - drip_days: list of ISO weekdays (1=Mon, 7=Sun)                │
+# │                                                                    │
+# │ 2. Add the option to input_select.garden_irrigation_mode           │
+# │    in config.yaml                                                  │
+# │                                                                    │
+# │ That's it — resolved attributes pick up the new profile            │
+# │ automatically. Scripts and automations need no changes.            │
+# │                                                                    │
+# │ Profile reference:                                                 │
+# │   Eco:       lawn 10min 2x/wk, drip 30min 3x/wk                  │
+# │   Standard:  lawn 15min 3x/wk, drip 45min weekdays                │
+# │   Intensive: lawn 20min daily,  drip 60min daily                   │
+# │   Smart:     auto-selects based on month + temperature             │
+# └─────────────────────────────────────────────────────────────────────┘
+sensor:
+  - name: Garden Irrigation Profile
+    unique_id: garden_irrigation_profile
+    icon: mdi:sprinkler-variant
+    state: "{{ states('input_select.garden_irrigation_mode') }}"
+    attributes:
+      profiles: >
+        {{ {
+          'Eco':       {'lawn_duration': 10, 'drip_duration': 30,
+                        'lawn_days': [1, 4],       'drip_days': [1, 3, 5]},
+          'Standard':  {'lawn_duration': 15, 'drip_duration': 45,
+                        'lawn_days': [1, 3, 5],    'drip_days': [1, 2, 3, 4, 5]},
+          'Intensive': {'lawn_duration': 20, 'drip_duration': 60,
+                        'lawn_days': [1, 2, 3, 4, 5, 6, 7],
+                        'drip_days': [1, 2, 3, 4, 5, 6, 7]},
+        } }}
+      lawn_duration: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} 20
+          {% elif month in [5, 9] %} 10
+          {% elif month in [6, 8] %} 15
+          {% elif month == 7 %} 20
+          {% else %} 15 {% endif %}
+        {% else %}
+          {{ profiles.get(mode, profiles['Standard'])['lawn_duration'] }}
+        {% endif %}
+      drip_duration: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} 60
+          {% elif month in [5, 9] %} 30
+          {% elif month in [6, 8] %} 45
+          {% elif month == 7 %} 60
+          {% else %} 45 {% endif %}
+        {% else %}
+          {{ profiles.get(mode, profiles['Standard'])['drip_duration'] }}
+        {% endif %}
+      lawn_today: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% set dow = now().isoweekday() %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} true
+          {% elif month in [5, 9] %} {{ dow in [1, 4] }}
+          {% elif month in [6, 8] %} {{ dow in [1, 3, 5] }}
+          {% elif month == 7 %} {{ dow in [1, 2, 3, 4, 5] }}
+          {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+        {% else %}
+          {{ dow in profiles.get(mode, profiles['Standard'])['lawn_days'] }}
+        {% endif %}
+      drip_today: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% set dow = now().isoweekday() %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} true
+          {% elif month in [5, 9] %} {{ dow in [1, 3, 5] }}
+          {% elif month in [6, 8] %} {{ dow in [1, 2, 3, 4, 5] }}
+          {% elif month == 7 %} true
+          {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+        {% else %}
+          {{ dow in profiles.get(mode, profiles['Standard'])['drip_days'] }}
+        {% endif %}
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
+git commit -m "feat(garden): add irrigation profile sensor with mode-driven durations and days"
+```
+
+---
+
+### Task 4: Create valve auto-off automation
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml`
+
+- [ ] **Step 1: Create the auto-off automation**
+
+Create `packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml`:
+
+```yaml
+---
+alias: Garden Valve Auto Off
+description: >
+  Automatically closes any irrigation valve after the profile-driven
+  duration. This is the main duration controller — scripts just open
+  valves and wait for this automation to close them. Also serves as
+  a safety net for manually opened valves via HomeKit.
+id: garden-valve-auto-off
+
+mode: parallel
+max: 4
+
+trigger:
+  - platform: state
+    entity_id:
+      - valve.lawn_sprinkler_zone_1
+      - valve.lawn_sprinkler_zone_2
+      - valve.lawn_sprinkler_zone_3
+    to: "open"
+    id: "lawn"
+  - platform: state
+    entity_id: valve.drip_irrigation
+    to: "open"
+    id: "drip"
+
+action:
+  - variables:
+      duration: >
+        {% if trigger.id == 'lawn' %}
+          {{ state_attr('sensor.garden_irrigation_profile', 'lawn_duration') | int(15) }}
+        {% else %}
+          {{ state_attr('sensor.garden_irrigation_profile', 'drip_duration') | int(45) }}
+        {% endif %}
+  - delay:
+      minutes: "{{ duration }}"
+  - action: valve.close
+    target:
+      entity_id: "{{ trigger.entity_id }}"
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
+git commit -m "feat(garden): add valve auto-off automation as single duration controller"
+```
+
+---
+
+### Task 5: Create irrigation scripts
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml`
+- Create: `packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml`
+- Create: `packages/areas/outdoor/garden/scripts/garden_full_irrigation.yaml`
+
+- [ ] **Step 1: Create sequential lawn irrigation script**
+
+Create `packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml`:
+
+```yaml
+---
+garden_lawn_irrigation:
+  alias: Garden Lawn Irrigation
+  description: >
+    Runs lawn zones 1→2→3 sequentially. Opens each valve and waits
+    for the auto-off automation to close it before moving to the next.
+  icon: mdi:sprinkler
+  mode: single
+  sequence:
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_1
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_2
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_2
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_3
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_3
+          to: "closed"
+      timeout:
+        minutes: 30
+```
+
+- [ ] **Step 2: Create drip irrigation script**
+
+Create `packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml`:
+
+```yaml
+---
+garden_drip_irrigation:
+  alias: Garden Drip Irrigation
+  description: >
+    Opens drip irrigation valve and waits for auto-off to close it.
+  icon: mdi:water-outline
+  mode: single
+  sequence:
+    - action: valve.open
+      target:
+        entity_id: valve.drip_irrigation
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.drip_irrigation
+          to: "closed"
+      timeout:
+        minutes: 90
+```
+
+- [ ] **Step 3: Create full irrigation script**
+
+Create `packages/areas/outdoor/garden/scripts/garden_full_irrigation.yaml`:
+
+```yaml
+---
+garden_full_irrigation:
+  alias: Garden Full Irrigation
+  description: >
+    Runs complete irrigation sequence: all 3 lawn zones followed by
+    drip irrigation. Each step waits for the previous to finish.
+  icon: mdi:watering-can
+  mode: single
+  sequence:
+    - action: script.garden_lawn_irrigation
+    - delay:
+        seconds: 5
+    - action: script.garden_drip_irrigation
+```
+
+- [ ] **Step 4: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml packages/areas/outdoor/garden/scripts/garden_full_irrigation.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/scripts/
+git commit -m "feat(garden): add lawn, drip, and full irrigation scripts"
+```
+
+---
+
+### Task 6: Create scheduled irrigation automation
+
+**Files:**
+- Create: `packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml`
+
+- [ ] **Step 1: Create the scheduled automation**
+
+Create `packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml`:
+
+```yaml
+---
+alias: Garden Scheduled Irrigation
+description: >
+  Fires daily at 6 AM. Checks skip conditions (rain, season), then
+  checks which parts (lawn, drip) should run today based on the
+  active irrigation profile.
+id: garden-scheduled-irrigation
+
+mode: single
+
+trigger:
+  - platform: time
+    at: "06:00:00"
+
+condition:
+  - condition: state
+    entity_id: binary_sensor.garden_should_skip_irrigation
+    state: "off"
+
+action:
+  - variables:
+      lawn_today: "{{ state_attr('sensor.garden_irrigation_profile', 'lawn_today') }}"
+      drip_today: "{{ state_attr('sensor.garden_irrigation_profile', 'drip_today') }}"
+  - choose:
+      - conditions:
+          - "{{ lawn_today }}"
+          - "{{ drip_today }}"
+        sequence:
+          - action: script.garden_full_irrigation
+      - conditions:
+          - "{{ lawn_today }}"
+        sequence:
+          - action: script.garden_lawn_irrigation
+      - conditions:
+          - "{{ drip_today }}"
+        sequence:
+          - action: script.garden_drip_irrigation
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
+git commit -m "feat(garden): add scheduled irrigation automation with weather-aware skip logic"
+```
+
+---
+
+### Task 7: Add HomeKit integration
+
+**Files:**
+- Modify: `packages/homekit/config.yaml:88-89` (add valve and script entities to include list)
+- Modify: `packages/homekit/config.yaml:206-207` (add entity_config entries)
+
+- [ ] **Step 1: Add entities to HomeKit include list**
+
+In `packages/homekit/config.yaml`, after the existing `# Garden` section (line 88-89), replace:
+
+```yaml
+      # Garden
+      - lawn_mower.garden
+```
+
+with:
+
+```yaml
+      # Garden
+      - lawn_mower.garden
+      - valve.lawn_sprinkler_zone_1
+      - valve.lawn_sprinkler_zone_2
+      - valve.lawn_sprinkler_zone_3
+      - valve.drip_irrigation
+      - script.garden_lawn_irrigation
+      - script.garden_full_irrigation
+```
+
+- [ ] **Step 2: Add entity_config entries**
+
+In `packages/homekit/config.yaml`, after the `lawn_mower.garden` entity_config entry (line 207), add:
+
+```yaml
+    valve.lawn_sprinkler_zone_1:
+      name: Lawn Zone 1
+    valve.lawn_sprinkler_zone_2:
+      name: Lawn Zone 2
+    valve.lawn_sprinkler_zone_3:
+      name: Lawn Zone 3
+    valve.drip_irrigation:
+      name: Drip Irrigation
+    script.garden_lawn_irrigation:
+      name: Lawn Irrigation
+    script.garden_full_irrigation:
+      name: Full Irrigation
+```
+
+- [ ] **Step 3: Verify YAML is valid**
+
+```bash
+uv run yamllint packages/homekit/config.yaml
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/homekit/config.yaml
+git commit -m "feat(garden): expose irrigation valves and scripts to HomeKit"
+```
+
+---
+
+### Task 8: Lint all files and push
+
+**Files:**
+- All files created/modified in tasks 1-7
+
+- [ ] **Step 1: Run full lint check**
+
+```bash
+uv run yamllint .
+```
+
+Expected: no errors from garden files
+
+- [ ] **Step 2: Run pre-commit hooks**
+
+```bash
+uv run pre-commit run --all-files
+```
+
+Expected: all checks pass
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push origin feature/sprinkle
+```
+
+---
+
+### Task 9: Generate area README
+
+- [ ] **Step 1: Generate README using ha-area-docs skill**
+
+Run `/ha-area-docs` skill for the garden area package to generate `packages/areas/outdoor/garden/README.md`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/areas/outdoor/garden/README.md
+git commit -m "docs(garden): add area README for irrigation package"
+```

--- a/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
+++ b/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
@@ -1,0 +1,382 @@
+# Garden Irrigation Automation — Design Spec
+
+**Date:** 2026-04-10
+**Area package:** `packages/areas/outdoor/garden/`
+
+## Overview
+
+Automated irrigation system for a 4-zone Tuya sprinkler controller in Poland. Three lawn zones run sequentially (never simultaneously), followed by drip irrigation for flowers/plants. Behavior is driven by an `input_select` mode selector with a profile-based configuration system.
+
+## Entities
+
+### Valve Entities (existing, from Tuya Local)
+
+| Entity ID | Purpose |
+|---|---|
+| `valve.lawn_sprinkler_zone_1` | Lawn zone 1 |
+| `valve.lawn_sprinkler_zone_2` | Lawn zone 2 |
+| `valve.lawn_sprinkler_zone_3` | Lawn zone 3 |
+| `valve.drip_irrigation` | Drip irrigation (flowers/plants) |
+| `valve.garden_all_valves` | All valves (not used by automation) |
+
+Zones 5–8 are unused (controller only supports 4 physical zones).
+
+### Helper Entities (new)
+
+| Entity ID | Type | Purpose |
+|---|---|---|
+| `input_select.garden_irrigation_mode` | input_select | Mode selector: Eco, Standard, Intensive, Smart |
+
+## Area Package Structure
+
+```
+packages/areas/outdoor/garden/
+├── config.yaml
+├── automations/
+│   └── garden_scheduled_irrigation.yaml
+├── scripts/
+│   ├── garden_lawn_zone_1.yaml
+│   ├── garden_lawn_zone_2.yaml
+│   ├── garden_lawn_zone_3.yaml
+│   ├── garden_lawn_irrigation.yaml
+│   ├── garden_drip_irrigation.yaml
+│   └── garden_full_irrigation.yaml
+└── templates/
+    ├── garden_irrigation_profile.yaml
+    └── garden_should_skip_irrigation.yaml
+```
+
+## Config — `config.yaml`
+
+```yaml
+input_select:
+  garden_irrigation_mode:
+    name: Garden Irrigation Mode
+    options:
+      - Eco
+      - Standard
+      - Intensive
+      - Smart
+    initial: Smart
+    icon: mdi:sprinkler
+```
+
+HomeKit exposure for on-demand control:
+
+```yaml
+homekit:
+  filter:
+    include_entities:
+      - script.garden_full_irrigation
+      - script.garden_lawn_irrigation
+      - script.garden_drip_irrigation
+      - script.garden_lawn_zone_1
+      - script.garden_lawn_zone_2
+      - script.garden_lawn_zone_3
+```
+
+## Skip Logic — `garden_should_skip_irrigation.yaml`
+
+Binary sensor that gates whether irrigation should run. Returns `on` when irrigation should be **skipped**.
+
+```yaml
+- binary_sensor:
+    - name: Garden Should Skip Irrigation
+      unique_id: garden_should_skip_irrigation
+      icon: mdi:water-off
+      state: >
+        {% set is_raining = is_state('binary_sensor.raining', 'on') %}
+        {% set month = now().month %}
+        {% set in_season = month >= 5 and month <= 9 %}
+        {% set rain_forecast = state_attr('weather.forecast_home', 'forecast')
+            | default([])
+            | selectattr('datetime', 'le', (now() + timedelta(hours=6)).isoformat())
+            | selectattr('condition', 'in', ['rainy', 'pouring', 'lightning-rainy'])
+            | list
+            | count > 0 %}
+        {{ is_raining or rain_forecast or not in_season }}
+      attributes:
+        reason: >
+          {% if not (now().month >= 5 and now().month <= 9) %}
+            out_of_season
+          {% elif is_state('binary_sensor.raining', 'on') %}
+            raining_now
+          {% elif state_attr('weather.forecast_home', 'forecast')
+              | default([])
+              | selectattr('datetime', 'le', (now() + timedelta(hours=6)).isoformat())
+              | selectattr('condition', 'in', ['rainy', 'pouring', 'lightning-rainy'])
+              | list
+              | count > 0 %}
+            rain_forecast_within_6h
+          {% else %}
+            none
+          {% endif %}
+```
+
+Skip conditions:
+- **Out of season:** Before May or after September
+- **Currently raining:** Uses existing `binary_sensor.raining`
+- **Rain forecasted within 6 hours:** Checks Met.no hourly forecast
+- **Future-ready:** Add `{% set soil_too_wet = ... %}` when soil moisture sensor is available
+
+Note: In HA 2024.x+, `forecast` is no longer a direct attribute — use `weather.get_forecasts` service call via a trigger-based template sensor or `action` in the template. During implementation, verify which approach the current HA version supports and adapt accordingly.
+
+## Irrigation Profile — `garden_irrigation_profile.yaml`
+
+Template sensor with a profiles dictionary for easy mode management.
+
+```yaml
+- sensor:
+    - name: Garden Irrigation Profile
+      unique_id: garden_irrigation_profile
+      icon: mdi:sprinkler-variant
+      state: "{{ states('input_select.garden_irrigation_mode') }}"
+      attributes:
+        profiles: >
+          {{ {
+            'Eco':       {'lawn_duration': 10, 'drip_duration': 30,
+                          'lawn_days': [1, 4],       'drip_days': [1, 3, 5]},
+            'Standard':  {'lawn_duration': 15, 'drip_duration': 45,
+                          'lawn_days': [1, 3, 5],    'drip_days': [1, 2, 3, 4, 5]},
+            'Intensive': {'lawn_duration': 20, 'drip_duration': 60,
+                          'lawn_days': [1, 2, 3, 4, 5, 6, 7], 'drip_days': [1, 2, 3, 4, 5, 6, 7]},
+          } }}
+        lawn_duration: >
+          {% set mode = states('input_select.garden_irrigation_mode') %}
+          {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+          {% if mode == 'Smart' %}
+            {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+            {% set month = now().month %}
+            {% if temp >= 30 %} 20
+            {% elif month in [5, 9] %} 10
+            {% elif month in [6, 8] %} 15
+            {% elif month == 7 %} 20
+            {% else %} 15 {% endif %}
+          {% else %}
+            {{ profiles.get(mode, profiles['Standard'])['lawn_duration'] }}
+          {% endif %}
+        drip_duration: >
+          {% set mode = states('input_select.garden_irrigation_mode') %}
+          {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+          {% if mode == 'Smart' %}
+            {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+            {% set month = now().month %}
+            {% if temp >= 30 %} 60
+            {% elif month in [5, 9] %} 30
+            {% elif month in [6, 8] %} 45
+            {% elif month == 7 %} 60
+            {% else %} 45 {% endif %}
+          {% else %}
+            {{ profiles.get(mode, profiles['Standard'])['drip_duration'] }}
+          {% endif %}
+        lawn_today: >
+          {% set mode = states('input_select.garden_irrigation_mode') %}
+          {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+          {% set dow = now().isoweekday() %}
+          {% if mode == 'Smart' %}
+            {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+            {% set month = now().month %}
+            {% if temp >= 30 %} true
+            {% elif month in [5, 9] %} {{ dow in [1, 4] }}
+            {% elif month in [6, 8] %} {{ dow in [1, 3, 5] }}
+            {% elif month == 7 %} {{ dow in [1, 2, 3, 4, 5] }}
+            {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+          {% else %}
+            {{ dow in profiles.get(mode, profiles['Standard'])['lawn_days'] }}
+          {% endif %}
+        drip_today: >
+          {% set mode = states('input_select.garden_irrigation_mode') %}
+          {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+          {% set dow = now().isoweekday() %}
+          {% if mode == 'Smart' %}
+            {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+            {% set month = now().month %}
+            {% if temp >= 30 %} true
+            {% elif month in [5, 9] %} {{ dow in [1, 3, 5] }}
+            {% elif month in [6, 8] %} {{ dow in [1, 2, 3, 4, 5] }}
+            {% elif month == 7 %} true
+            {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+          {% else %}
+            {{ dow in profiles.get(mode, profiles['Standard'])['drip_days'] }}
+          {% endif %}
+```
+
+### Adding a New Mode
+
+To add a new irrigation mode (e.g., "Seedling"):
+
+1. **Add the profile** to the `profiles` attribute dictionary in `garden_irrigation_profile.yaml`:
+   ```yaml
+   'Seedling': {'lawn_duration': 5, 'drip_duration': 20,
+                'lawn_days': [1, 2, 3, 4, 5, 6, 7], 'drip_days': [1, 2, 3, 4, 5, 6, 7]},
+   ```
+2. **Add the option** to `input_select.garden_irrigation_mode` in `config.yaml`:
+   ```yaml
+   options:
+     - Eco
+     - Standard
+     - Intensive
+     - Seedling    # ← new
+     - Smart
+   ```
+
+That's it. The resolved attributes (`lawn_duration`, `drip_duration`, `lawn_today`, `drip_today`) automatically pick up the new profile. Scripts and automations require no changes.
+
+### Profile Reference
+
+| Mode | Lawn days | Lawn min/zone | Drip days | Drip min |
+|---|---|---|---|---|
+| Eco | Mon, Thu | 10 | Mon, Wed, Fri | 30 |
+| Standard | Mon, Wed, Fri | 15 | Weekdays | 45 |
+| Intensive | Daily | 20 | Daily | 60 |
+| Smart | Season + temp driven | Season + temp driven | Season + temp driven | Season + temp driven |
+
+### Smart Mode Logic
+
+Smart mode dynamically selects durations and days based on current month and temperature:
+
+| Condition | Lawn duration | Lawn days | Drip duration | Drip days |
+|---|---|---|---|---|
+| Temp ≥ 30°C (heatwave) | 20 min | Daily | 60 min | Daily |
+| July | 20 min | Mon–Fri | 60 min | Daily |
+| June, August | 15 min | Mon, Wed, Fri | 45 min | Weekdays |
+| May, September | 10 min | Mon, Thu | 30 min | Mon, Wed, Fri |
+| Default (fallback) | 15 min | Mon, Wed, Fri | 45 min | Mon, Wed, Fri |
+
+## Scripts
+
+### Individual Zone Scripts
+
+Each zone has its own script for HomeKit/on-demand control. Pattern (zone 1 shown):
+
+```yaml
+garden_lawn_zone_1:
+  alias: Garden Lawn Zone 1
+  icon: mdi:sprinkler
+  mode: single
+  sequence:
+    - variables:
+        duration: "{{ state_attr('sensor.garden_irrigation_profile', 'lawn_duration') | int(15) }}"
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
+    - delay:
+        minutes: "{{ duration }}"
+    - action: valve.close
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
+```
+
+Zones 2 and 3 follow the same pattern with their respective entities.
+
+### Sequential Lawn Script — `garden_lawn_irrigation.yaml`
+
+Chains zones 1→2→3 by calling individual zone scripts:
+
+```yaml
+garden_lawn_irrigation:
+  alias: Garden Lawn Irrigation
+  icon: mdi:sprinkler
+  mode: single
+  sequence:
+    - action: script.garden_lawn_zone_1
+    - action: script.garden_lawn_zone_2
+    - action: script.garden_lawn_zone_3
+```
+
+### Drip Script — `garden_drip_irrigation.yaml`
+
+```yaml
+garden_drip_irrigation:
+  alias: Garden Drip Irrigation
+  icon: mdi:water-outline
+  mode: single
+  sequence:
+    - variables:
+        duration: "{{ state_attr('sensor.garden_irrigation_profile', 'drip_duration') | int(45) }}"
+    - action: valve.open
+      target:
+        entity_id: valve.drip_irrigation
+    - delay:
+        minutes: "{{ duration }}"
+    - action: valve.close
+      target:
+        entity_id: valve.drip_irrigation
+```
+
+### Full Irrigation Script — `garden_full_irrigation.yaml`
+
+Lawn then drip, chained (drip starts after lawn finishes):
+
+```yaml
+garden_full_irrigation:
+  alias: Garden Full Irrigation
+  icon: mdi:watering-can
+  mode: single
+  sequence:
+    - action: script.garden_lawn_irrigation
+    - action: script.garden_drip_irrigation
+```
+
+## Scheduled Automation — `garden_scheduled_irrigation.yaml`
+
+Fires at 6 AM daily. Checks skip conditions, then checks which parts should run today.
+
+```yaml
+- id: garden_scheduled_irrigation
+  alias: Garden Scheduled Irrigation
+  mode: single
+  trigger:
+    - platform: time
+      at: "06:00:00"
+  condition:
+    - condition: state
+      entity_id: binary_sensor.garden_should_skip_irrigation
+      state: "off"
+  action:
+    - variables:
+        lawn_today: "{{ state_attr('sensor.garden_irrigation_profile', 'lawn_today') }}"
+        drip_today: "{{ state_attr('sensor.garden_irrigation_profile', 'drip_today') }}"
+    - choose:
+        - conditions:
+            - "{{ lawn_today }}"
+            - "{{ drip_today }}"
+          sequence:
+            - action: script.garden_full_irrigation
+        - conditions:
+            - "{{ lawn_today }}"
+          sequence:
+            - action: script.garden_lawn_irrigation
+        - conditions:
+            - "{{ drip_today }}"
+          sequence:
+            - action: script.garden_drip_irrigation
+```
+
+## HomeKit Integration
+
+Exposed as switches in HomeKit for Siri/Home app control:
+
+| HomeKit Name | Script | Use Case |
+|---|---|---|
+| Garden Full Irrigation | `script.garden_full_irrigation` | "Hey Siri, turn on Garden Full Irrigation" |
+| Garden Lawn Irrigation | `script.garden_lawn_irrigation` | All 3 lawn zones sequential |
+| Garden Lawn Zone 1/2/3 | `script.garden_lawn_zone_{1,2,3}` | Individual zone on-demand |
+| Garden Drip Irrigation | `script.garden_drip_irrigation` | Drip only on-demand |
+
+## Design Decisions
+
+1. **Script-centric approach** — scripts handle sequencing and durations, automations handle scheduling and conditions. Clean separation of *when* vs *what*.
+2. **Profile dictionary** — single place to define mode parameters. Adding a mode is a 2-line change (dict entry + input_select option).
+3. **Smart mode in templates** — no separate automation to switch modes. Smart computes values dynamically from season and temperature.
+4. **Shared skip logic** — one binary sensor gates both lawn and drip. Both skip for rain, forecast, and out-of-season.
+5. **mode: single on all scripts** — prevents overlapping runs (hardware limitation: valves can't run simultaneously).
+6. **Composable scripts** — individual zone scripts are called by the sequential script. On-demand and scheduled use the same scripts.
+7. **Future soil moisture** — skip logic sensor is ready for an additional condition when a moisture sensor is added.
+
+## Out of Scope
+
+- Dashboard cards for irrigation (can be added later)
+- Notifications (e.g., "irrigation skipped due to rain")
+- Water usage tracking
+- Soil moisture sensor integration (designed for, not implemented)

--- a/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
+++ b/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
@@ -57,8 +57,8 @@ input_select:
       - Standard
       - Intensive
       - Smart
-    initial: Smart
     icon: mdi:sprinkler
+    # No 'initial' — HA persists last selected value across restarts
 ```
 
 HomeKit exposure for on-demand control:

--- a/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
+++ b/docs/superpowers/specs/2026-04-10-garden-irrigation-design.md
@@ -33,11 +33,9 @@ Zones 5–8 are unused (controller only supports 4 physical zones).
 packages/areas/outdoor/garden/
 ├── config.yaml
 ├── automations/
-│   └── garden_scheduled_irrigation.yaml
+│   ├── garden_scheduled_irrigation.yaml
+│   └── garden_valve_auto_off.yaml
 ├── scripts/
-│   ├── garden_lawn_zone_1.yaml
-│   ├── garden_lawn_zone_2.yaml
-│   ├── garden_lawn_zone_3.yaml
 │   ├── garden_lawn_irrigation.yaml
 │   ├── garden_drip_irrigation.yaml
 │   └── garden_full_irrigation.yaml
@@ -61,18 +59,20 @@ input_select:
     # No 'initial' — HA persists last selected value across restarts
 ```
 
-HomeKit exposure for on-demand control:
+HomeKit exposure — valves directly for on/off control, scripts for sequencing:
 
 ```yaml
 homekit:
   filter:
     include_entities:
-      - script.garden_full_irrigation
+      # Valves (direct on/off control, auto-off handles duration)
+      - valve.lawn_sprinkler_zone_1
+      - valve.lawn_sprinkler_zone_2
+      - valve.lawn_sprinkler_zone_3
+      - valve.drip_irrigation
+      # Scripts (sequential runs)
       - script.garden_lawn_irrigation
-      - script.garden_drip_irrigation
-      - script.garden_lawn_zone_1
-      - script.garden_lawn_zone_2
-      - script.garden_lawn_zone_3
+      - script.garden_full_irrigation
 ```
 
 ## Skip Logic — `garden_should_skip_irrigation.yaml`
@@ -243,35 +243,58 @@ Smart mode dynamically selects durations and days based on current month and tem
 | May, September | 10 min | Mon, Thu | 30 min | Mon, Wed, Fri |
 | Default (fallback) | 15 min | Mon, Wed, Fri | 45 min | Mon, Wed, Fri |
 
-## Scripts
+## Valve Auto-Off Automation — `garden_valve_auto_off.yaml`
 
-### Individual Zone Scripts
-
-Each zone has its own script for HomeKit/on-demand control. Pattern (zone 1 shown):
+The **single source of truth** for valve durations. Any valve opened (via HomeKit, script, or schedule) is automatically closed after the profile-driven duration.
 
 ```yaml
-garden_lawn_zone_1:
-  alias: Garden Lawn Zone 1
-  icon: mdi:sprinkler
-  mode: single
-  sequence:
+- id: garden_valve_auto_off
+  alias: Garden Valve Auto Off
+  description: >
+    Automatically closes any irrigation valve after the profile-driven
+    duration. This is the main duration controller — scripts just
+    open valves and wait for this automation to close them.
+  mode: parallel
+  max: 4
+
+  trigger:
+    - platform: state
+      entity_id:
+        - valve.lawn_sprinkler_zone_1
+        - valve.lawn_sprinkler_zone_2
+        - valve.lawn_sprinkler_zone_3
+      to: "open"
+      id: "lawn"
+    - platform: state
+      entity_id: valve.drip_irrigation
+      to: "open"
+      id: "drip"
+
+  action:
     - variables:
-        duration: "{{ state_attr('sensor.garden_irrigation_profile', 'lawn_duration') | int(15) }}"
-    - action: valve.open
-      target:
-        entity_id: valve.lawn_sprinkler_zone_1
+        duration: >
+          {% if trigger.id == 'lawn' %}
+            {{ state_attr('sensor.garden_irrigation_profile', 'lawn_duration') | int(15) }}
+          {% else %}
+            {{ state_attr('sensor.garden_irrigation_profile', 'drip_duration') | int(45) }}
+          {% endif %}
     - delay:
         minutes: "{{ duration }}"
     - action: valve.close
       target:
-        entity_id: valve.lawn_sprinkler_zone_1
+        entity_id: "{{ trigger.entity_id }}"
 ```
 
-Zones 2 and 3 follow the same pattern with their respective entities.
+Key design points:
+- `mode: parallel` with `max: 4` — allows multiple valves to have independent auto-off timers (safety net, even though only one should run at a time)
+- Duration is read from profile sensor at the moment the valve opens
+- Works identically whether valve is opened via HomeKit, script, or automation
+
+## Scripts
+
+Scripts are pure sequencers — they open valves and wait for the auto-off automation to close them. They don't manage durations.
 
 ### Sequential Lawn Script — `garden_lawn_irrigation.yaml`
-
-Chains zones 1→2→3 by calling individual zone scripts:
 
 ```yaml
 garden_lawn_irrigation:
@@ -279,9 +302,37 @@ garden_lawn_irrigation:
   icon: mdi:sprinkler
   mode: single
   sequence:
-    - action: script.garden_lawn_zone_1
-    - action: script.garden_lawn_zone_2
-    - action: script.garden_lawn_zone_3
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_1
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_2
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_2
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_3
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_3
+          to: "closed"
+      timeout:
+        minutes: 30
 ```
 
 ### Drip Script — `garden_drip_irrigation.yaml`
@@ -292,21 +343,20 @@ garden_drip_irrigation:
   icon: mdi:water-outline
   mode: single
   sequence:
-    - variables:
-        duration: "{{ state_attr('sensor.garden_irrigation_profile', 'drip_duration') | int(45) }}"
     - action: valve.open
       target:
         entity_id: valve.drip_irrigation
-    - delay:
-        minutes: "{{ duration }}"
-    - action: valve.close
-      target:
-        entity_id: valve.drip_irrigation
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.drip_irrigation
+          to: "closed"
+      timeout:
+        minutes: 90
 ```
 
 ### Full Irrigation Script — `garden_full_irrigation.yaml`
 
-Lawn then drip, chained (drip starts after lawn finishes):
+Lawn then drip, chained (drip starts 5s after last lawn zone closes):
 
 ```yaml
 garden_full_irrigation:
@@ -315,6 +365,8 @@ garden_full_irrigation:
   mode: single
   sequence:
     - action: script.garden_lawn_irrigation
+    - delay:
+        seconds: 5
     - action: script.garden_drip_irrigation
 ```
 
@@ -355,24 +407,30 @@ Fires at 6 AM daily. Checks skip conditions, then checks which parts should run 
 
 ## HomeKit Integration
 
-Exposed as switches in HomeKit for Siri/Home app control:
+Valves exposed directly for on/off control. Scripts exposed for sequential runs.
 
-| HomeKit Name | Script | Use Case |
+| HomeKit Name | Entity | Use Case |
 |---|---|---|
-| Garden Full Irrigation | `script.garden_full_irrigation` | "Hey Siri, turn on Garden Full Irrigation" |
-| Garden Lawn Irrigation | `script.garden_lawn_irrigation` | All 3 lawn zones sequential |
-| Garden Lawn Zone 1/2/3 | `script.garden_lawn_zone_{1,2,3}` | Individual zone on-demand |
-| Garden Drip Irrigation | `script.garden_drip_irrigation` | Drip only on-demand |
+| Lawn Sprinkler Zone 1 | `valve.lawn_sprinkler_zone_1` | Open/close individual zone |
+| Lawn Sprinkler Zone 2 | `valve.lawn_sprinkler_zone_2` | Open/close individual zone |
+| Lawn Sprinkler Zone 3 | `valve.lawn_sprinkler_zone_3` | Open/close individual zone |
+| Drip Irrigation | `valve.drip_irrigation` | Open/close drip |
+| Garden Lawn Irrigation | `script.garden_lawn_irrigation` | Sequential zones 1→2→3 |
+| Garden Full Irrigation | `script.garden_full_irrigation` | Lawn then drip sequence |
+
+Opening a valve via HomeKit → auto-off closes it after profile duration.
+Closing a valve via HomeKit → stops immediately.
 
 ## Design Decisions
 
-1. **Script-centric approach** — scripts handle sequencing and durations, automations handle scheduling and conditions. Clean separation of *when* vs *what*.
-2. **Profile dictionary** — single place to define mode parameters. Adding a mode is a 2-line change (dict entry + input_select option).
-3. **Smart mode in templates** — no separate automation to switch modes. Smart computes values dynamically from season and temperature.
-4. **Shared skip logic** — one binary sensor gates both lawn and drip. Both skip for rain, forecast, and out-of-season.
-5. **mode: single on all scripts** — prevents overlapping runs (hardware limitation: valves can't run simultaneously).
-6. **Composable scripts** — individual zone scripts are called by the sequential script. On-demand and scheduled use the same scripts.
-7. **Future soil moisture** — skip logic sensor is ready for an additional condition when a moisture sensor is added.
+1. **Auto-off as single source of truth** — one automation controls all valve durations. Scripts are pure sequencers that open valves and wait for close. Duration logic lives in one place.
+2. **Direct valve exposure to HomeKit** — valves are exposed directly (not wrapped in scripts). Users can open/close any valve on demand. Auto-off handles duration automatically.
+3. **Profile dictionary** — single place to define mode parameters. Adding a mode is a 2-line change (dict entry + input_select option).
+4. **Smart mode in templates** — no separate automation to switch modes. Smart computes values dynamically from season and temperature.
+5. **Shared skip logic** — one binary sensor gates both lawn and drip. Both skip for rain, forecast, and out-of-season.
+6. **mode: single on scripts, mode: parallel on auto-off** — scripts prevent overlapping sequences, auto-off handles independent valve timers.
+7. **wait_for_trigger pattern** — scripts wait for the valve to close (driven by auto-off) plus 5s grace period before opening the next zone. No duration knowledge needed in scripts.
+8. **Future soil moisture** — skip logic sensor is ready for an additional condition when a moisture sensor is added.
 
 ## Out of Scope
 

--- a/packages/areas/outdoor/garden/README.md
+++ b/packages/areas/outdoor/garden/README.md
@@ -1,0 +1,84 @@
+# Garden
+
+> Automated irrigation for 3 lawn zones and drip irrigation, driven by mode profiles with weather-aware scheduling.
+
+**Package:** `garden` | **Path:** `packages/areas/outdoor/garden/`
+
+## How It Works
+
+### Scheduled Irrigation
+
+Every morning at 6:00 AM, the system checks two things: should it skip (rain, forecast, season), and what should run today (lawn, drip, or both). The active mode determines which days each type runs and for how long.
+
+Irrigation only operates **May through September**. It also skips if it's currently raining or rain is forecasted within 6 hours (using Met.no). The `reason` attribute on the skip sensor makes it easy to see why irrigation was skipped.
+
+### Modes
+
+`input_select.garden_irrigation_mode` controls everything. The mode persists across HA restarts.
+
+| Mode | Lawn | Drip |
+|------|------|------|
+| **Eco** | 10 min/zone, Mon + Thu | 30 min, Mon + Wed + Fri |
+| **Standard** | 15 min/zone, Mon + Wed + Fri | 45 min, weekdays |
+| **Intensive** | 20 min/zone, daily | 60 min, daily |
+| **Smart** | Auto-selects based on month and temperature | Same logic, different values |
+
+Smart mode ramps up through the season: lighter in May/September, heavier in July, and overrides to Intensive-level during heatwaves (>30°C).
+
+**Adding a new mode** requires just two edits: add a profile entry in `garden_irrigation_profile.yaml` and add the option to `input_select` in `config.yaml`. See the inline docs in the profile template for details.
+
+### How Valves Are Controlled
+
+The **auto-off automation** is the single source of truth for durations. Any valve that opens — whether via schedule, script, or HomeKit — gets automatically closed after the profile-driven duration. Scripts don't manage durations; they just open valves and wait for them to close.
+
+The **lawn irrigation script** runs zones sequentially: opens zone 1, waits for auto-off to close it, pauses 5 seconds, opens zone 2, and so on. The **full irrigation script** chains the lawn script followed by drip.
+
+### On-Demand Control
+
+All 4 valves and 2 sequence scripts are exposed to **HomeKit**:
+
+- Open any individual valve — auto-off handles the duration
+- Close any valve — stops immediately
+- Trigger `script.garden_lawn_irrigation` — runs all 3 zones sequentially
+- Trigger `script.garden_full_irrigation` — lawn zones then drip
+
+## Gotchas
+
+- **Valves can't run simultaneously** — the Tuya controller doesn't support it. The sequential scripts enforce this, but if you manually open two valves via HomeKit, the hardware may not behave as expected.
+- **Auto-off reads duration at valve-open time** — changing the mode mid-run won't affect an already-running valve, but the next valve in a sequence will pick up the new duration.
+- **Forecast attribute access** — `weather.forecast_home` forecast attribute may need adaptation for newer HA versions that use the `weather.get_forecasts` service instead.
+- **Zones 5-8 on the Tuya controller are unused** — the hardware supports 4 physical zones only.
+
+## Entities
+
+**Valves:** `valve.lawn_sprinkler_zone_1`, `valve.lawn_sprinkler_zone_2`, `valve.lawn_sprinkler_zone_3`, `valve.drip_irrigation`
+
+**Mode:** `input_select.garden_irrigation_mode` — Eco / Standard / Intensive / Smart
+
+**Sensors:**
+- `binary_sensor.garden_should_skip_irrigation` — on = skip (check `reason` attribute)
+- `sensor.garden_irrigation_profile` — resolved durations and schedule (check `lawn_duration`, `drip_duration`, `lawn_today`, `drip_today` attributes)
+
+**Scripts:**
+- `script.garden_lawn_irrigation` — zones 1→2→3 sequential
+- `script.garden_drip_irrigation` — drip only
+- `script.garden_full_irrigation` — lawn then drip
+
+## Dependencies
+
+- `binary_sensor.raining` — current rain state (from `packages/bootstrap/templates/`)
+- `weather.forecast_home` — Met.no weather forecast for rain lookahead and temperature
+- `sun.sun` — indirectly via season logic (month-based)
+
+## File Index
+
+| File | Purpose |
+|------|---------|
+| `config.yaml` | Package entry, input_select definition |
+| `automations/garden_valve_auto_off.yaml` | Auto-closes valves after profile duration |
+| `automations/garden_scheduled_irrigation.yaml` | Daily 6 AM trigger with skip logic |
+| `scripts/garden_lawn_irrigation.yaml` | Sequential zones 1→2→3 |
+| `scripts/garden_drip_irrigation.yaml` | Drip valve with wait-for-close |
+| `scripts/garden_full_irrigation.yaml` | Chains lawn + drip scripts |
+| `templates/garden_should_skip_irrigation.yaml` | Skip logic (rain, forecast, season) |
+| `templates/garden_irrigation_profile.yaml` | Mode → duration/days mapping |

--- a/packages/areas/outdoor/garden/automations/garden_irrigation_cleanup.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_irrigation_cleanup.yaml
@@ -1,0 +1,32 @@
+---
+alias: Garden Irrigation Cleanup
+description: >
+  When an irrigation script is stopped (e.g. via HomeKit "turn off"),
+  closes all valves and stops any child scripts to prevent leaks.
+id: garden-irrigation-cleanup
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id:
+      - script.garden_lawn_irrigation
+      - script.garden_full_irrigation
+      - script.garden_drip_irrigation
+    from: "on"
+    to: "off"
+
+action:
+  - action: script.turn_off
+    target:
+      entity_id:
+        - script.garden_lawn_irrigation
+        - script.garden_full_irrigation
+        - script.garden_drip_irrigation
+  - action: valve.close
+    target:
+      entity_id:
+        - valve.lawn_sprinkler_zone_1
+        - valve.lawn_sprinkler_zone_2
+        - valve.lawn_sprinkler_zone_3
+        - valve.drip_irrigation

--- a/packages/areas/outdoor/garden/automations/garden_irrigation_cleanup.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_irrigation_cleanup.yaml
@@ -23,7 +23,7 @@ action:
         - script.garden_lawn_irrigation
         - script.garden_full_irrigation
         - script.garden_drip_irrigation
-  - action: valve.close
+  - action: valve.close_valve
     target:
       entity_id:
         - valve.lawn_sprinkler_zone_1

--- a/packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
@@ -13,6 +13,11 @@ trigger:
     at: "06:00:00"
 
 condition:
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: input_select.garden_irrigation_mode
+        state: "Manual"
   - condition: state
     entity_id: binary_sensor.garden_should_skip_irrigation
     state: "off"

--- a/packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_scheduled_irrigation.yaml
@@ -1,0 +1,37 @@
+---
+alias: Garden Scheduled Irrigation
+description: >
+  Fires daily at 6 AM. Checks skip conditions (rain, season), then
+  checks which parts (lawn, drip) should run today based on the
+  active irrigation profile.
+id: garden-scheduled-irrigation
+
+mode: single
+
+trigger:
+  - platform: time
+    at: "06:00:00"
+
+condition:
+  - condition: state
+    entity_id: binary_sensor.garden_should_skip_irrigation
+    state: "off"
+
+action:
+  - variables:
+      lawn_today: "{{ state_attr('sensor.garden_irrigation_profile', 'lawn_today') }}"
+      drip_today: "{{ state_attr('sensor.garden_irrigation_profile', 'drip_today') }}"
+  - choose:
+      - conditions:
+          - "{{ lawn_today }}"
+          - "{{ drip_today }}"
+        sequence:
+          - action: script.garden_full_irrigation
+      - conditions:
+          - "{{ lawn_today }}"
+        sequence:
+          - action: script.garden_lawn_irrigation
+      - conditions:
+          - "{{ drip_today }}"
+        sequence:
+          - action: script.garden_drip_irrigation

--- a/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
@@ -1,0 +1,40 @@
+---
+alias: Garden Valve Auto Off
+description: >
+  Automatically closes any irrigation valve after the profile-driven
+  duration. This is the main duration controller — scripts just open
+  valves and wait for this automation to close them. Also serves as
+  a safety net for manually opened valves via HomeKit.
+id: garden-valve-auto-off
+
+mode: parallel
+max: 4
+
+trigger:
+  - platform: state
+    entity_id:
+      - valve.lawn_sprinkler_zone_1
+      - valve.lawn_sprinkler_zone_2
+      - valve.lawn_sprinkler_zone_3
+    to: "open"
+    id: "lawn"
+  - platform: state
+    entity_id: valve.drip_irrigation
+    to: "open"
+    id: "drip"
+
+action:
+  - variables:
+      duration: >
+        {% if trigger.id == 'lawn' %}
+          {{ state_attr('sensor.garden_irrigation_profile',
+             'lawn_duration') | int(15) }}
+        {% else %}
+          {{ state_attr('sensor.garden_irrigation_profile',
+             'drip_duration') | int(45) }}
+        {% endif %}
+  - delay:
+      minutes: "{{ duration }}"
+  - action: valve.close
+    target:
+      entity_id: "{{ trigger.entity_id }}"

--- a/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
@@ -35,6 +35,6 @@ action:
         {% endif %}
   - delay:
       seconds: "{{ duration }}"
-  - action: valve.close
+  - action: valve.close_valve
     target:
       entity_id: "{{ trigger.entity_id }}"

--- a/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_valve_auto_off.yaml
@@ -28,13 +28,13 @@ action:
       duration: >
         {% if trigger.id == 'lawn' %}
           {{ state_attr('sensor.garden_irrigation_profile',
-             'lawn_duration') | int(15) }}
+             'lawn_duration') | int(900) }}
         {% else %}
           {{ state_attr('sensor.garden_irrigation_profile',
-             'drip_duration') | int(45) }}
+             'drip_duration') | int(2700) }}
         {% endif %}
   - delay:
-      minutes: "{{ duration }}"
+      seconds: "{{ duration }}"
   - action: valve.close
     target:
       entity_id: "{{ trigger.entity_id }}"

--- a/packages/areas/outdoor/garden/config.yaml
+++ b/packages/areas/outdoor/garden/config.yaml
@@ -7,6 +7,7 @@ input_select:
   garden_irrigation_mode:
     name: Garden Irrigation Mode
     options:
+      - Manual
       - Eco
       - Standard
       - Intensive

--- a/packages/areas/outdoor/garden/config.yaml
+++ b/packages/areas/outdoor/garden/config.yaml
@@ -1,0 +1,14 @@
+---
+automation: !include_dir_list automations
+template: !include_dir_list templates
+script: !include_dir_merge_named scripts
+
+input_select:
+  garden_irrigation_mode:
+    name: Garden Irrigation Mode
+    options:
+      - Eco
+      - Standard
+      - Intensive
+      - Smart
+    icon: mdi:sprinkler

--- a/packages/areas/outdoor/garden/config.yaml
+++ b/packages/areas/outdoor/garden/config.yaml
@@ -10,5 +10,6 @@ input_select:
       - Eco
       - Standard
       - Intensive
+      - Testing
       - Smart
     icon: mdi:sprinkler

--- a/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
@@ -15,3 +15,6 @@ garden_drip_irrigation:
           to: "closed"
       timeout:
         minutes: 90
+    - action: valve.close
+      target:
+        entity_id: valve.drip_irrigation

--- a/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
@@ -1,0 +1,17 @@
+---
+garden_drip_irrigation:
+  alias: Garden Drip Irrigation
+  description: >
+    Opens drip irrigation valve and waits for auto-off to close it.
+  icon: mdi:water-outline
+  mode: single
+  sequence:
+    - action: valve.open
+      target:
+        entity_id: valve.drip_irrigation
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.drip_irrigation
+          to: "closed"
+      timeout:
+        minutes: 90

--- a/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_drip_irrigation.yaml
@@ -6,7 +6,7 @@ garden_drip_irrigation:
   icon: mdi:water-outline
   mode: single
   sequence:
-    - action: valve.open
+    - action: valve.open_valve
       target:
         entity_id: valve.drip_irrigation
     - wait_for_trigger:
@@ -15,6 +15,6 @@ garden_drip_irrigation:
           to: "closed"
       timeout:
         minutes: 90
-    - action: valve.close
+    - action: valve.close_valve
       target:
         entity_id: valve.drip_irrigation

--- a/packages/areas/outdoor/garden/scripts/garden_full_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_full_irrigation.yaml
@@ -1,0 +1,13 @@
+---
+garden_full_irrigation:
+  alias: Garden Full Irrigation
+  description: >
+    Runs complete irrigation sequence: all 3 lawn zones followed by
+    drip irrigation. Each step waits for the previous to finish.
+  icon: mdi:watering-can
+  mode: single
+  sequence:
+    - action: script.garden_lawn_irrigation
+    - delay:
+        seconds: 5
+    - action: script.garden_drip_irrigation

--- a/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
@@ -16,6 +16,9 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
+    - action: valve.close
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
     - delay:
         seconds: 5
     - action: valve.open
@@ -27,6 +30,9 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
+    - action: valve.close
+      target:
+        entity_id: valve.lawn_sprinkler_zone_2
     - delay:
         seconds: 5
     - action: valve.open
@@ -38,3 +44,6 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
+    - action: valve.close
+      target:
+        entity_id: valve.lawn_sprinkler_zone_3

--- a/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
@@ -7,7 +7,7 @@ garden_lawn_irrigation:
   icon: mdi:sprinkler
   mode: single
   sequence:
-    - action: valve.open
+    - action: valve.open_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_1
     - wait_for_trigger:
@@ -16,12 +16,12 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
-    - action: valve.close
+    - action: valve.close_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_1
     - delay:
         seconds: 5
-    - action: valve.open
+    - action: valve.open_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_2
     - wait_for_trigger:
@@ -30,12 +30,12 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
-    - action: valve.close
+    - action: valve.close_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_2
     - delay:
         seconds: 5
-    - action: valve.open
+    - action: valve.open_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_3
     - wait_for_trigger:
@@ -44,6 +44,6 @@ garden_lawn_irrigation:
           to: "closed"
       timeout:
         minutes: 30
-    - action: valve.close
+    - action: valve.close_valve
       target:
         entity_id: valve.lawn_sprinkler_zone_3

--- a/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
+++ b/packages/areas/outdoor/garden/scripts/garden_lawn_irrigation.yaml
@@ -1,0 +1,40 @@
+---
+garden_lawn_irrigation:
+  alias: Garden Lawn Irrigation
+  description: >
+    Runs lawn zones 1→2→3 sequentially. Opens each valve and waits
+    for the auto-off automation to close it before moving to the next.
+  icon: mdi:sprinkler
+  mode: single
+  sequence:
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_1
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_1
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_2
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_2
+          to: "closed"
+      timeout:
+        minutes: 30
+    - delay:
+        seconds: 5
+    - action: valve.open
+      target:
+        entity_id: valve.lawn_sprinkler_zone_3
+    - wait_for_trigger:
+        - platform: state
+          entity_id: valve.lawn_sprinkler_zone_3
+          to: "closed"
+      timeout:
+        minutes: 30

--- a/packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
@@ -1,0 +1,102 @@
+---
+# Garden Irrigation Profile
+#
+# Maps the selected irrigation mode to durations (minutes) and schedule days.
+# The 'profiles' attribute is a dictionary — the single source of truth
+# for all non-Smart mode parameters.
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ HOW TO ADD A NEW MODE                                              │
+# │                                                                    │
+# │ 1. Add an entry to the 'profiles' dict below with:                │
+# │    - lawn_duration: minutes per lawn zone                          │
+# │    - drip_duration: minutes for drip irrigation                    │
+# │    - lawn_days: list of ISO weekdays (1=Mon, 7=Sun)                │
+# │    - drip_days: list of ISO weekdays (1=Mon, 7=Sun)                │
+# │                                                                    │
+# │ 2. Add the option to input_select.garden_irrigation_mode           │
+# │    in config.yaml                                                  │
+# │                                                                    │
+# │ That's it — resolved attributes pick up the new profile            │
+# │ automatically. Scripts and automations need no changes.            │
+# │                                                                    │
+# │ Profile reference:                                                 │
+# │   Eco:       lawn 10min 2x/wk, drip 30min 3x/wk                  │
+# │   Standard:  lawn 15min 3x/wk, drip 45min weekdays                │
+# │   Intensive: lawn 20min daily,  drip 60min daily                   │
+# │   Smart:     auto-selects based on month + temperature             │
+# └─────────────────────────────────────────────────────────────────────┘
+sensor:
+  - name: Garden Irrigation Profile
+    unique_id: garden_irrigation_profile
+    icon: mdi:sprinkler-variant
+    state: "{{ states('input_select.garden_irrigation_mode') }}"
+    attributes:
+      profiles: >
+        {{ {
+          'Eco':       {'lawn_duration': 10, 'drip_duration': 30,
+                        'lawn_days': [1, 4],       'drip_days': [1, 3, 5]},
+          'Standard':  {'lawn_duration': 15, 'drip_duration': 45,
+                        'lawn_days': [1, 3, 5],    'drip_days': [1, 2, 3, 4, 5]},
+          'Intensive': {'lawn_duration': 20, 'drip_duration': 60,
+                        'lawn_days': [1, 2, 3, 4, 5, 6, 7],
+                        'drip_days': [1, 2, 3, 4, 5, 6, 7]},
+        } }}
+      lawn_duration: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} 20
+          {% elif month in [5, 9] %} 10
+          {% elif month in [6, 8] %} 15
+          {% elif month == 7 %} 20
+          {% else %} 15 {% endif %}
+        {% else %}
+          {{ profiles.get(mode, profiles['Standard'])['lawn_duration'] }}
+        {% endif %}
+      drip_duration: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} 60
+          {% elif month in [5, 9] %} 30
+          {% elif month in [6, 8] %} 45
+          {% elif month == 7 %} 60
+          {% else %} 45 {% endif %}
+        {% else %}
+          {{ profiles.get(mode, profiles['Standard'])['drip_duration'] }}
+        {% endif %}
+      lawn_today: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% set dow = now().isoweekday() %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} true
+          {% elif month in [5, 9] %} {{ dow in [1, 4] }}
+          {% elif month in [6, 8] %} {{ dow in [1, 3, 5] }}
+          {% elif month == 7 %} {{ dow in [1, 2, 3, 4, 5] }}
+          {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+        {% else %}
+          {{ dow in profiles.get(mode, profiles['Standard'])['lawn_days'] }}
+        {% endif %}
+      drip_today: >
+        {% set mode = states('input_select.garden_irrigation_mode') %}
+        {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
+        {% set dow = now().isoweekday() %}
+        {% if mode == 'Smart' %}
+          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set month = now().month %}
+          {% if temp >= 30 %} true
+          {% elif month in [5, 9] %} {{ dow in [1, 3, 5] }}
+          {% elif month in [6, 8] %} {{ dow in [1, 2, 3, 4, 5] }}
+          {% elif month == 7 %} true
+          {% else %} {{ dow in [1, 3, 5] }} {% endif %}
+        {% else %}
+          {{ dow in profiles.get(mode, profiles['Standard'])['drip_days'] }}
+        {% endif %}

--- a/packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_irrigation_profile.yaml
@@ -1,7 +1,7 @@
 ---
 # Garden Irrigation Profile
 #
-# Maps the selected irrigation mode to durations (minutes) and schedule days.
+# Maps the selected irrigation mode to durations and schedule days.
 # The 'profiles' attribute is a dictionary — the single source of truth
 # for all non-Smart mode parameters.
 #
@@ -9,8 +9,8 @@
 # │ HOW TO ADD A NEW MODE                                              │
 # │                                                                    │
 # │ 1. Add an entry to the 'profiles' dict below with:                │
-# │    - lawn_duration: minutes per lawn zone                          │
-# │    - drip_duration: minutes for drip irrigation                    │
+# │    - lawn_duration: duration string (e.g. 30s, 10m, 1h)           │
+# │    - drip_duration: duration string (e.g. 30s, 10m, 1h)           │
 # │    - lawn_days: list of ISO weekdays (1=Mon, 7=Sun)                │
 # │    - drip_days: list of ISO weekdays (1=Mon, 7=Sun)                │
 # │                                                                    │
@@ -21,10 +21,15 @@
 # │ automatically. Scripts and automations need no changes.            │
 # │                                                                    │
 # │ Profile reference:                                                 │
-# │   Eco:       lawn 10min 2x/wk, drip 30min 3x/wk                  │
-# │   Standard:  lawn 15min 3x/wk, drip 45min weekdays                │
-# │   Intensive: lawn 20min daily,  drip 60min daily                   │
+# │   Eco:       lawn 10m 2x/wk, drip 30m 3x/wk                      │
+# │   Standard:  lawn 15m 3x/wk, drip 45m weekdays                    │
+# │   Intensive: lawn 20m daily,  drip 1h daily                        │
+# │   Testing:   all valves 30s daily (for validation)                 │
 # │   Smart:     auto-selects based on month + temperature             │
+# │                                                                    │
+# │ Duration format: number + unit suffix (s=seconds, m=minutes,       │
+# │ h=hours). Resolved attributes output seconds for the auto-off      │
+# │ automation.                                                        │
 # └─────────────────────────────────────────────────────────────────────┘
 sensor:
   - name: Garden Irrigation Profile
@@ -34,11 +39,14 @@ sensor:
     attributes:
       profiles: >
         {{ {
-          'Eco':       {'lawn_duration': 10, 'drip_duration': 30,
+          'Eco':       {'lawn_duration': '10m', 'drip_duration': '30m',
                         'lawn_days': [1, 4],       'drip_days': [1, 3, 5]},
-          'Standard':  {'lawn_duration': 15, 'drip_duration': 45,
+          'Standard':  {'lawn_duration': '15m', 'drip_duration': '45m',
                         'lawn_days': [1, 3, 5],    'drip_days': [1, 2, 3, 4, 5]},
-          'Intensive': {'lawn_duration': 20, 'drip_duration': 60,
+          'Intensive': {'lawn_duration': '20m', 'drip_duration': '1h',
+                        'lawn_days': [1, 2, 3, 4, 5, 6, 7],
+                        'drip_days': [1, 2, 3, 4, 5, 6, 7]},
+          'Testing':   {'lawn_duration': '30s', 'drip_duration': '30s',
                         'lawn_days': [1, 2, 3, 4, 5, 6, 7],
                         'drip_days': [1, 2, 3, 4, 5, 6, 7]},
         } }}
@@ -46,36 +54,45 @@ sensor:
         {% set mode = states('input_select.garden_irrigation_mode') %}
         {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
         {% if mode == 'Smart' %}
-          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set temp = state_attr('weather.forecast_home',
+              'temperature') | float(20) %}
           {% set month = now().month %}
-          {% if temp >= 30 %} 20
-          {% elif month in [5, 9] %} 10
-          {% elif month in [6, 8] %} 15
-          {% elif month == 7 %} 20
-          {% else %} 15 {% endif %}
+          {% if temp >= 30 %} 1200
+          {% elif month in [5, 9] %} 600
+          {% elif month in [6, 8] %} 900
+          {% elif month == 7 %} 1200
+          {% else %} 900 {% endif %}
         {% else %}
-          {{ profiles.get(mode, profiles['Standard'])['lawn_duration'] }}
+          {% set d = profiles.get(mode, profiles['Standard'])['lawn_duration'] %}
+          {% set u = d[-1] %}
+          {% set v = d[:-1] | int %}
+          {{ v * {'s': 1, 'm': 60, 'h': 3600}[u] }}
         {% endif %}
       drip_duration: >
         {% set mode = states('input_select.garden_irrigation_mode') %}
         {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
         {% if mode == 'Smart' %}
-          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set temp = state_attr('weather.forecast_home',
+              'temperature') | float(20) %}
           {% set month = now().month %}
-          {% if temp >= 30 %} 60
-          {% elif month in [5, 9] %} 30
-          {% elif month in [6, 8] %} 45
-          {% elif month == 7 %} 60
-          {% else %} 45 {% endif %}
+          {% if temp >= 30 %} 3600
+          {% elif month in [5, 9] %} 1800
+          {% elif month in [6, 8] %} 2700
+          {% elif month == 7 %} 3600
+          {% else %} 2700 {% endif %}
         {% else %}
-          {{ profiles.get(mode, profiles['Standard'])['drip_duration'] }}
+          {% set d = profiles.get(mode, profiles['Standard'])['drip_duration'] %}
+          {% set u = d[-1] %}
+          {% set v = d[:-1] | int %}
+          {{ v * {'s': 1, 'm': 60, 'h': 3600}[u] }}
         {% endif %}
       lawn_today: >
         {% set mode = states('input_select.garden_irrigation_mode') %}
         {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
         {% set dow = now().isoweekday() %}
         {% if mode == 'Smart' %}
-          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set temp = state_attr('weather.forecast_home',
+              'temperature') | float(20) %}
           {% set month = now().month %}
           {% if temp >= 30 %} true
           {% elif month in [5, 9] %} {{ dow in [1, 4] }}
@@ -90,7 +107,8 @@ sensor:
         {% set profiles = state_attr('sensor.garden_irrigation_profile', 'profiles') %}
         {% set dow = now().isoweekday() %}
         {% if mode == 'Smart' %}
-          {% set temp = state_attr('weather.forecast_home', 'temperature') | float(20) %}
+          {% set temp = state_attr('weather.forecast_home',
+              'temperature') | float(20) %}
           {% set month = now().month %}
           {% if temp >= 30 %} true
           {% elif month in [5, 9] %} {{ dow in [1, 3, 5] }}

--- a/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
@@ -7,56 +7,56 @@
 #
 # Uses trigger-based template with weather.get_forecasts service
 # (forecast attribute was removed in HA 2024.x).
-- trigger:
-    - platform: time_pattern
-      minutes: "/30"
-    - platform: homeassistant
-      event: start
-    - platform: state
-      entity_id: binary_sensor.raining
-  action:
-    - action: weather.get_forecasts
-      target:
-        entity_id: weather.forecast_home
-      data:
-        type: hourly
-      response_variable: forecast_response
-  binary_sensor:
-    - name: Garden Should Skip Irrigation
-      unique_id: garden_should_skip_irrigation
-      icon: mdi:water-off
-      state: >
-        {% set is_raining = is_state('binary_sensor.raining', 'on') %}
+trigger:
+  - platform: time_pattern
+    minutes: "/30"
+  - platform: homeassistant
+    event: start
+  - platform: state
+    entity_id: binary_sensor.raining
+action:
+  - action: weather.get_forecasts
+    target:
+      entity_id: weather.forecast_home
+    data:
+      type: hourly
+    response_variable: forecast_response
+binary_sensor:
+  - name: Garden Should Skip Irrigation
+    unique_id: garden_should_skip_irrigation
+    icon: mdi:water-off
+    state: >
+      {% set is_raining = is_state('binary_sensor.raining', 'on') %}
+      {% set month = now().month %}
+      {% set in_season = month >= 5 and month <= 9 %}
+      {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+      {% set forecast = forecast_response['weather.forecast_home']
+          ['forecast'] | default([]) %}
+      {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+      {% set rain_forecast = forecast
+          | selectattr('datetime', 'le', cutoff)
+          | selectattr('condition', 'in', rain_conditions)
+          | list
+          | count > 0 %}
+      {{ is_raining or rain_forecast or not in_season }}
+    attributes:
+      reason: >
         {% set month = now().month %}
         {% set in_season = month >= 5 and month <= 9 %}
         {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
         {% set forecast = forecast_response['weather.forecast_home']
             ['forecast'] | default([]) %}
         {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
-        {% set rain_forecast = forecast
+        {% if not in_season %}
+          out_of_season
+        {% elif is_state('binary_sensor.raining', 'on') %}
+          raining_now
+        {% elif forecast
             | selectattr('datetime', 'le', cutoff)
             | selectattr('condition', 'in', rain_conditions)
             | list
             | count > 0 %}
-        {{ is_raining or rain_forecast or not in_season }}
-      attributes:
-        reason: >
-          {% set month = now().month %}
-          {% set in_season = month >= 5 and month <= 9 %}
-          {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
-          {% set forecast = forecast_response['weather.forecast_home']
-              ['forecast'] | default([]) %}
-          {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
-          {% if not in_season %}
-            out_of_season
-          {% elif is_state('binary_sensor.raining', 'on') %}
-            raining_now
-          {% elif forecast
-              | selectattr('datetime', 'le', cutoff)
-              | selectattr('condition', 'in', rain_conditions)
-              | list
-              | count > 0 %}
-            rain_forecast_within_6h
-          {% else %}
-            none
-          {% endif %}
+          rain_forecast_within_6h
+        {% else %}
+          none
+        {% endif %}

--- a/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
@@ -4,40 +4,59 @@
 # Returns 'on' when irrigation should be SKIPPED.
 # Checks: season (May-Sep only), current rain, rain forecast (6h lookahead).
 # Future: add soil moisture check when sensor is available.
-binary_sensor:
-  - name: Garden Should Skip Irrigation
-    unique_id: garden_should_skip_irrigation
-    icon: mdi:water-off
-    state: >
-      {% set is_raining = is_state('binary_sensor.raining', 'on') %}
-      {% set month = now().month %}
-      {% set in_season = month >= 5 and month <= 9 %}
-      {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
-      {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
-      {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
-      {% set rain_forecast = forecast
-          | selectattr('datetime', 'le', cutoff)
-          | selectattr('condition', 'in', rain_conditions)
-          | list
-          | count > 0 %}
-      {{ is_raining or rain_forecast or not in_season }}
-    attributes:
-      reason: >
+#
+# Uses trigger-based template with weather.get_forecasts service
+# (forecast attribute was removed in HA 2024.x).
+- trigger:
+    - platform: time_pattern
+      minutes: "/30"
+    - platform: homeassistant
+      event: start
+    - platform: state
+      entity_id: binary_sensor.raining
+  action:
+    - action: weather.get_forecasts
+      target:
+        entity_id: weather.forecast_home
+      data:
+        type: hourly
+      response_variable: forecast_response
+  binary_sensor:
+    - name: Garden Should Skip Irrigation
+      unique_id: garden_should_skip_irrigation
+      icon: mdi:water-off
+      state: >
+        {% set is_raining = is_state('binary_sensor.raining', 'on') %}
         {% set month = now().month %}
         {% set in_season = month >= 5 and month <= 9 %}
         {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
-        {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
+        {% set forecast = forecast_response['weather.forecast_home']
+            ['forecast'] | default([]) %}
         {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
-        {% if not in_season %}
-          out_of_season
-        {% elif is_state('binary_sensor.raining', 'on') %}
-          raining_now
-        {% elif forecast
+        {% set rain_forecast = forecast
             | selectattr('datetime', 'le', cutoff)
             | selectattr('condition', 'in', rain_conditions)
             | list
             | count > 0 %}
-          rain_forecast_within_6h
-        {% else %}
-          none
-        {% endif %}
+        {{ is_raining or rain_forecast or not in_season }}
+      attributes:
+        reason: >
+          {% set month = now().month %}
+          {% set in_season = month >= 5 and month <= 9 %}
+          {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+          {% set forecast = forecast_response['weather.forecast_home']
+              ['forecast'] | default([]) %}
+          {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+          {% if not in_season %}
+            out_of_season
+          {% elif is_state('binary_sensor.raining', 'on') %}
+            raining_now
+          {% elif forecast
+              | selectattr('datetime', 'le', cutoff)
+              | selectattr('condition', 'in', rain_conditions)
+              | list
+              | count > 0 %}
+            rain_forecast_within_6h
+          {% else %}
+            none
+          {% endif %}

--- a/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
@@ -1,0 +1,43 @@
+---
+# Garden Should Skip Irrigation
+#
+# Returns 'on' when irrigation should be SKIPPED.
+# Checks: season (May-Sep only), current rain, rain forecast (6h lookahead).
+# Future: add soil moisture check when sensor is available.
+binary_sensor:
+  - name: Garden Should Skip Irrigation
+    unique_id: garden_should_skip_irrigation
+    icon: mdi:water-off
+    state: >
+      {% set is_raining = is_state('binary_sensor.raining', 'on') %}
+      {% set month = now().month %}
+      {% set in_season = month >= 5 and month <= 9 %}
+      {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+      {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
+      {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+      {% set rain_forecast = forecast
+          | selectattr('datetime', 'le', cutoff)
+          | selectattr('condition', 'in', rain_conditions)
+          | list
+          | count > 0 %}
+      {{ is_raining or rain_forecast or not in_season }}
+    attributes:
+      reason: >
+        {% set month = now().month %}
+        {% set in_season = month >= 5 and month <= 9 %}
+        {% set rain_conditions = ['rainy', 'pouring', 'lightning-rainy'] %}
+        {% set forecast = state_attr('weather.forecast_home', 'forecast') | default([]) %}
+        {% set cutoff = (now() + timedelta(hours=6)).isoformat() %}
+        {% if not in_season %}
+          out_of_season
+        {% elif is_state('binary_sensor.raining', 'on') %}
+          raining_now
+        {% elif forecast
+            | selectattr('datetime', 'le', cutoff)
+            | selectattr('condition', 'in', rain_conditions)
+            | list
+            | count > 0 %}
+          rain_forecast_within_6h
+        {% else %}
+          none
+        {% endif %}

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -212,17 +212,17 @@ homekit:
     lawn_mower.garden:
       name: Garden Mower
     valve.lawn_sprinkler_zone_1:
-      name: Lawn Zone 1
+      name: Sprinkler One
     valve.lawn_sprinkler_zone_2:
-      name: Lawn Zone 2
+      name: Sprinkler Two
     valve.lawn_sprinkler_zone_3:
-      name: Lawn Zone 3
+      name: Sprinkler Three
     valve.drip_irrigation:
       name: Drip Irrigation
     script.garden_lawn_irrigation:
-      name: Lawn Irrigation
+      name: Lawn Sprinklers
     script.garden_full_irrigation:
-      name: Full Irrigation
+      name: Garden Sprinklers
 
     alarm_control_panel.main:
       name: Alarm

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -212,11 +212,11 @@ homekit:
     lawn_mower.garden:
       name: Garden Mower
     valve.lawn_sprinkler_zone_1:
-      name: Sprinkler One
+      name: Lawn Zone One
     valve.lawn_sprinkler_zone_2:
-      name: Sprinkler Two
+      name: Lawn Zone Two
     valve.lawn_sprinkler_zone_3:
-      name: Sprinkler Three
+      name: Lawn Zone Three
     valve.drip_irrigation:
       name: Drip Irrigation
     script.garden_lawn_irrigation:

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -87,6 +87,12 @@ homekit:
 
       # Garden
       - lawn_mower.garden
+      - valve.lawn_sprinkler_zone_1
+      - valve.lawn_sprinkler_zone_2
+      - valve.lawn_sprinkler_zone_3
+      - valve.drip_irrigation
+      - script.garden_lawn_irrigation
+      - script.garden_full_irrigation
 
       # Alarm
       - alarm_control_panel.main
@@ -205,6 +211,18 @@ homekit:
 
     lawn_mower.garden:
       name: Garden Mower
+    valve.lawn_sprinkler_zone_1:
+      name: Lawn Zone 1
+    valve.lawn_sprinkler_zone_2:
+      name: Lawn Zone 2
+    valve.lawn_sprinkler_zone_3:
+      name: Lawn Zone 3
+    valve.drip_irrigation:
+      name: Drip Irrigation
+    script.garden_lawn_irrigation:
+      name: Lawn Irrigation
+    script.garden_full_irrigation:
+      name: Full Irrigation
 
     alarm_control_panel.main:
       name: Alarm

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -220,9 +220,9 @@ homekit:
     valve.drip_irrigation:
       name: Drip Irrigation
     script.garden_lawn_irrigation:
-      name: Lawn Sprinklers
+      name: Lawn Watering
     script.garden_full_irrigation:
-      name: Garden Sprinklers
+      name: Garden Watering
 
     alarm_control_panel.main:
       name: Alarm

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -212,11 +212,11 @@ homekit:
     lawn_mower.garden:
       name: Garden Mower
     valve.lawn_sprinkler_zone_1:
-      name: Lawn Zone One
+      name: Sprinkler One
     valve.lawn_sprinkler_zone_2:
-      name: Lawn Zone Two
+      name: Sprinkler Two
     valve.lawn_sprinkler_zone_3:
-      name: Lawn Zone Three
+      name: Sprinkler Three
     valve.drip_irrigation:
       name: Drip Irrigation
     script.garden_lawn_irrigation:

--- a/packages/misc/automations/misc_vacuum_reminder_first_floor.yaml
+++ b/packages/misc/automations/misc_vacuum_reminder_first_floor.yaml
@@ -1,0 +1,52 @@
+---
+alias: "Vacuum reminder: First Floor"
+description: >-
+  Remind to run the first floor vacuum when everyone leaves home
+  and it hasn't cleaned in 3 days.
+id: a1b2c3d4-e5f6-7890-abcd-vacuum-ff-rem
+
+mode: single
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id: binary_sensor.presence_someone_at_home
+    from: "on"
+    to: "off"
+    for:
+      minutes: 2
+
+condition:
+  - condition: template
+    value_template: >-
+      {{
+        (now() - states('sensor.x40_master_cleaning_history')
+          | as_datetime | default(now()))
+        > timedelta(days=3)
+      }}
+  - condition: template
+    value_template: >-
+      {{
+        this.attributes.last_triggered is none
+        or (now() - this.attributes.last_triggered) > timedelta(hours=23)
+      }}
+
+action:
+  - action: notify.mobile_app_iglofon_new
+    data:
+      title: "Vacuum Reminder"
+      message: >-
+        First floor vacuum hasn't cleaned since
+        {{ states('sensor.x40_master_cleaning_history')
+           | as_datetime | as_local
+           | string | truncate(16, true, '') }}.
+        Consider starting a clean while you're away.
+  - action: notify.mobile_app_iphone_uzivatela_sona
+    data:
+      title: "Vacuum Reminder"
+      message: >-
+        First floor vacuum hasn't cleaned since
+        {{ states('sensor.x40_master_cleaning_history')
+           | as_datetime | as_local
+           | string | truncate(16, true, '') }}.
+        Consider starting a clean while you're away.

--- a/packages/misc/automations/misc_vacuum_reminder_ground_floor.yaml
+++ b/packages/misc/automations/misc_vacuum_reminder_ground_floor.yaml
@@ -1,0 +1,52 @@
+---
+alias: "Vacuum reminder: Ground Floor"
+description: >-
+  Remind to run the ground floor vacuum when everyone leaves home
+  and it hasn't cleaned in 3 days.
+id: a1b2c3d4-e5f6-7890-abcd-vacuum-gf-rem
+
+mode: single
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id: binary_sensor.presence_someone_at_home
+    from: "on"
+    to: "off"
+    for:
+      minutes: 2
+
+condition:
+  - condition: template
+    value_template: >-
+      {{
+        (now() - states('sensor.dreamebot_l10_ultra_cleaning_history')
+          | as_datetime | default(now()))
+        > timedelta(days=3)
+      }}
+  - condition: template
+    value_template: >-
+      {{
+        this.attributes.last_triggered is none
+        or (now() - this.attributes.last_triggered) > timedelta(hours=23)
+      }}
+
+action:
+  - action: notify.mobile_app_iglofon_new
+    data:
+      title: "Vacuum Reminder"
+      message: >-
+        Ground floor vacuum hasn't cleaned since
+        {{ states('sensor.dreamebot_l10_ultra_cleaning_history')
+           | as_datetime | as_local
+           | string | truncate(16, true, '') }}.
+        Consider starting a clean while you're away.
+  - action: notify.mobile_app_iphone_uzivatela_sona
+    data:
+      title: "Vacuum Reminder"
+      message: >-
+        Ground floor vacuum hasn't cleaned since
+        {{ states('sensor.dreamebot_l10_ultra_cleaning_history')
+           | as_datetime | as_local
+           | string | truncate(16, true, '') }}.
+        Consider starting a clean while you're away.


### PR DESCRIPTION
## Summary

- Adds a new `garden` area package (`packages/areas/outdoor/garden/`) with a fully automated irrigation system for a 4-zone Tuya sprinkler controller
- Mode-driven profiles (Eco / Standard / Intensive / Smart) control duration and frequency for 3 lawn zones + drip irrigation
- Weather-aware skip logic (current rain, 6h forecast, May–Sep season lockout)
- Auto-off automation as single source of truth for valve durations — scripts are pure sequencers
- HomeKit integration exposes individual valves (on/off) and sequence scripts (lawn, full)

### Architecture

- `input_select.garden_irrigation_mode` — persists across restarts, drives all behavior
- `sensor.garden_irrigation_profile` — template sensor with profiles dict for easy mode addition (2-line change)
- `binary_sensor.garden_should_skip_irrigation` — gates scheduled runs with `reason` attribute for debugging
- `garden_valve_auto_off` automation (parallel mode) — closes any opened valve after profile duration
- Scripts use `wait_for_trigger` pattern — open valve, wait for auto-off to close it, 5s grace, next zone
- Scheduled automation fires daily at 6 AM, checks skip + profile to decide what runs

## Test plan

- [ ] Verify HA loads config without errors after pull
- [ ] Check `sensor.garden_irrigation_profile` attributes resolve correctly for each mode
- [ ] Check `binary_sensor.garden_should_skip_irrigation` shows correct state/reason (currently April = `out_of_season`)
- [ ] Test on-demand: open single valve via HomeKit, confirm auto-off closes it after profile duration
- [ ] Test on-demand: trigger `script.garden_lawn_irrigation`, confirm zones run sequentially
- [ ] Test mode change: switch to Eco, verify durations/days update on profile sensor
- [ ] Verify HomeKit exposes all 4 valves and 2 scripts with correct names