### PR TITLE
fix(garden): trigger drip skip sensors on soil probe changes

### DIFF
--- a/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
+++ b/packages/areas/outdoor/garden/templates/garden_should_skip_irrigation.yaml
@@ -13,7 +13,11 @@ trigger:
   - platform: homeassistant
     event: start
   - platform: state
-    entity_id: binary_sensor.raining
+    entity_id:
+      - binary_sensor.raining
+      - sensor.pergola_left_flowerbed_soil_moisture
+      - sensor.pergola_right_flowerbed_soil_moisture
+      - sensor.sona_flowerbed_soil_moisture
 action:
   - action: weather.get_forecasts
     target:


### PR DESCRIPTION
Adds the 3 flowerbed soil probes as state triggers to the trigger-based skip-sensor block. Without them, `garden_drip_soil_skip` (and siblings) only re-evaluate every /30 min, on HA start, or on rain change — so after a `template.reload` they sit `unknown` until the next tick, and never reflect a mid-cycle probe change. Now they populate immediately on reload (probe state diff) and stay fresh as readings update.