### PR TITLE
✨ feat(supla): Supla cloud integration for ZAMEL ROW-02 relays

### DIFF
--- a/packages/areas/ground-floor/vestibule/README.md
+++ b/packages/areas/ground-floor/vestibule/README.md
@@ -9,7 +9,7 @@
 
 The vestibule has four ceiling bulbs grouped as a single controllable light. A single automation manages them based on presence and outdoor darkness.
 
-When the vestibule presence sensor detects someone and it is dark outside (determined by `binary_sensor.garden_is_dark`), the lights turn on. Once presence clears for 1 minute, the lights turn off regardless of darkness state. The automation also re-evaluates on Home Assistant start and automation reload so that lights always reflect the current state after a restart.
+When the vestibule presence sensor detects someone and it is dark outside (determined by `binary_sensor.outdoor_is_dark`), the lights turn on. Once presence clears for 1 minute, the lights turn off regardless of darkness state. The automation also re-evaluates on Home Assistant start and automation reload so that lights always reflect the current state after a restart.
 
 The automation runs in `restart` mode, meaning each new trigger cancels any in-progress action sequence. This keeps behavior snappy -- if someone walks in and out quickly, the 1-minute vacancy delay resets correctly.
 
@@ -34,7 +34,7 @@ The automation runs in `restart` mode, meaning each new trigger cancels any in-p
 | Entity | Source | Role |
 |--------|--------|------|
 | `binary_sensor.vestibule_presence` | Zigbee2MQTT | Hardware presence sensor that triggers the automation |
-| `binary_sensor.garden_is_dark` | Outdoor templates | Gates daytime light activation |
+| `binary_sensor.outdoor_is_dark` | Bootstrap templates | Gates daytime light activation |
 | `light.mudroom` | HA device | The physical vestibule light controlled by the automation |
 
 ## File Index

--- a/packages/areas/ground-floor/vestibule/automations/vestibule_presence.yaml
+++ b/packages/areas/ground-floor/vestibule/automations/vestibule_presence.yaml
@@ -38,7 +38,7 @@ action:
                 entity_id: binary_sensor.vestibule_occupancy
                 state: "on"
               - condition: state
-                entity_id: binary_sensor.garden_is_dark
+                entity_id: binary_sensor.outdoor_is_dark
                 state: "on"
         sequence:
           - action: light.turn_on

--- a/packages/areas/outdoor/garden/README.md
+++ b/packages/areas/outdoor/garden/README.md
@@ -1,10 +1,24 @@
 # Garden
 
-> Automated irrigation for 3 lawn zones and drip irrigation, driven by mode profiles with heat-aware Smart scheduling.
+> Automated irrigation for 3 lawn zones and drip irrigation, driven by mode profiles with heat-aware Smart scheduling. Terrace doors drive the garden lights after dark.
 
 **Package:** `garden` | **Path:** `packages/areas/outdoor/garden/`
 
 ## How It Works
+
+### Lighting
+
+Five relay-driven light circuits (Supla cloud, 3× ZAMEL ROW-02 — integration configured in the
+`misc` package) live in the garden area: side lights, left reflectors (hedge), grill, corner,
+and back (far end). All are exposed to HomeKit.
+
+Opening either terrace door after dark (`binary_sensor.outdoor_is_dark`) turns on the **side
+lights** — the warm ambient pair flanking the garden. Closing **both** doors turns off **every
+light in the garden area**, dark or not, so lights are never stranded on. The off branch fires
+on each door-close but is gated on both doors being closed.
+
+Heads up: closing both doors while people are still out in the garden kills the lights — reopen
+a door (after dark) to get the side lights back.
 
 ### Scheduled Irrigation
 
@@ -134,6 +148,8 @@ The dashboards (tablet Outdoor + phone Garden room) carry a **Run Lawn Now** blo
 
 ## Entities
 
+**Lights:** `light.garden_side_lights`, `light.garden_left_reflectors`, `light.garden_grill_lights`, `light.garden_corner_lights`, `light.garden_back_lights` — switch_as_x wrappers over hidden Supla relay switches (registry-side, not YAML). Relay 299/1 has no load — disabled as "Garden Unused Relay 299-1".
+
 **Valves:** `valve.lawn_sprinkler_zone_1`, `valve.lawn_sprinkler_zone_2`, `valve.lawn_sprinkler_zone_3`, `valve.drip_irrigation`
 
 **Mode:** `input_select.garden_irrigation_mode` — Manual / Eco / Standard / Intensive / Testing / Smart / Seasonal
@@ -178,6 +194,8 @@ The dashboards (tablet Outdoor + phone Garden room) carry a **Run Lawn Now** blo
 
 ## Dependencies
 
+- `binary_sensor.terrace_left_door`, `binary_sensor.terrace_main_door` — Satel door zones; drive the garden lights
+- `binary_sensor.outdoor_is_dark` — sun-elevation darkness gate (from `bootstrap/`)
 - `binary_sensor.raining` — current rain state
 - `weather.forecast_home` — Met.no, hourly forecast fetch (drip skip + legacy)
 - `sensor.garden_forecast_today` — today's forecast high + UV + condition; drives Smart heat tiers (from `bootstrap/` or a dedicated template)
@@ -190,6 +208,7 @@ The dashboards (tablet Outdoor + phone Garden room) carry a **Run Lawn Now** blo
 | File | Purpose |
 |------|---------|
 | `config.yaml` | Package entry; helpers (input_select/number/datetime/boolean) + the `rest:` Open-Meteo rain sensor |
+| `automations/garden_lights_terrace_doors.yaml` | Terrace door open + dark → side lights on; both doors closed → all garden lights off |
 | `automations/garden_valve_auto_off.yaml` | Auto-closes valves after profile duration; skips lawn valves while an on-demand run is active |
 | `automations/garden_scheduled_irrigation.yaml` | 04:00 trigger with per-type skip gating (excludes Manual + Seasonal) |
 | `automations/garden_seasonal_irrigation.yaml` | Seasonal mode twice-daily (05:00/06:00/17:00) sessions; night guard, already-open abort, skip-only notify |

--- a/packages/areas/outdoor/garden/automations/garden_lights_terrace_doors.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_lights_terrace_doors.yaml
@@ -1,0 +1,53 @@
+---
+alias: Garden lights from terrace doors
+description: >
+  Terrace door opens after dark - turn on the garden side lights.
+  Both terrace doors closed - turn off all garden lights.
+id: f4bbc912-1ce9-41eb-93a9-273c9d764d9a
+
+mode: single
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id:
+      - binary_sensor.terrace_left_door
+      - binary_sensor.terrace_main_door
+    from: "off"
+    to: "on"
+    id: opened
+  - platform: state
+    entity_id:
+      - binary_sensor.terrace_left_door
+      - binary_sensor.terrace_main_door
+    from: "on"
+    to: "off"
+    id: closed
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: opened
+          - condition: state
+            entity_id: binary_sensor.outdoor_is_dark
+            state: "on"
+        sequence:
+          - service: light.turn_on
+            target:
+              entity_id: light.garden_side_lights
+
+      # Off only once BOTH doors are closed
+      - conditions:
+          - condition: trigger
+            id: closed
+          - condition: state
+            entity_id: binary_sensor.terrace_left_door
+            state: "off"
+          - condition: state
+            entity_id: binary_sensor.terrace_main_door
+            state: "off"
+        sequence:
+          - service: light.turn_off
+            target:
+              area_id: garden

--- a/packages/areas/outdoor/terrace/README.md
+++ b/packages/areas/outdoor/terrace/README.md
@@ -8,7 +8,7 @@
 
 The terrace package controls a single light (`light.terrace_wall`) based on whether someone is in the garden, whether a terrace door is being opened, and whether it is dark outside.
 
-When `binary_sensor.garden_presence` turns on and `binary_sensor.garden_is_dark` is also on, the terrace wall light switches on. When presence clears, the light turns off after a 30-second grace period. This delay prevents the light from flickering during brief gaps in motion detection. During daylight, presence is detected but the light stays off because the darkness condition gates the turn-on branch.
+When `binary_sensor.garden_presence` turns on and `binary_sensor.outdoor_is_dark` is also on, the terrace wall light switches on. When presence clears, the light turns off after a 30-second grace period. This delay prevents the light from flickering during brief gaps in motion detection. During daylight, presence is detected but the light stays off because the darkness condition gates the turn-on branch.
 
 In addition, opening either terrace door (`binary_sensor.terrace_left_door` or `binary_sensor.terrace_main_door`) after dark turns the light on immediately. The off-path is owned solely by the presence-based automation -- the door trigger never turns the light off.
 
@@ -27,7 +27,7 @@ The presence automation runs in `restart` mode and also re-evaluates on Home Ass
 |--------|------|------|
 | `light.terrace_wall` | Light | Controlled output |
 | `binary_sensor.garden_presence` | Binary sensor | Presence trigger |
-| `binary_sensor.garden_is_dark` | Binary sensor | Darkness gate |
+| `binary_sensor.outdoor_is_dark` | Binary sensor | Darkness gate |
 | `binary_sensor.terrace_left_door` | Binary sensor | Door trigger |
 | `binary_sensor.terrace_main_door` | Binary sensor | Door trigger |
 
@@ -36,7 +36,7 @@ The presence automation runs in `restart` mode and also re-evaluates on Home Ass
 All entities used by this package are defined outside of it:
 
 - `binary_sensor.garden_presence` -- garden occupancy sensor, primary trigger
-- `binary_sensor.garden_is_dark` -- darkness condition shared with other outdoor areas
+- `binary_sensor.outdoor_is_dark` -- darkness condition shared with other outdoor areas
 - `binary_sensor.terrace_left_door` -- Satel zone, door trigger
 - `binary_sensor.terrace_main_door` -- Satel zone, door trigger
 - `light.terrace_wall` -- physical light entity provided by the integration (e.g. Zigbee2MQTT)

--- a/packages/areas/outdoor/terrace/automations/garden_presence.yaml
+++ b/packages/areas/outdoor/terrace/automations/garden_presence.yaml
@@ -36,7 +36,7 @@ action:
                 entity_id: binary_sensor.garden_presence
                 state: "on"
               - condition: state
-                entity_id: binary_sensor.garden_is_dark
+                entity_id: binary_sensor.outdoor_is_dark
                 state: "on"
         sequence:
           - service: light.turn_on

--- a/packages/areas/outdoor/terrace/automations/terrace_door_trigger.yaml
+++ b/packages/areas/outdoor/terrace/automations/terrace_door_trigger.yaml
@@ -16,7 +16,7 @@ trigger:
 
 condition:
   - condition: state
-    entity_id: binary_sensor.garden_is_dark
+    entity_id: binary_sensor.outdoor_is_dark
     state: "on"
 
 action:

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -93,12 +93,11 @@ homekit:
 
       # Garden
       - lawn_mower.garden
-      - light.garden_light_1
-      - light.garden_light_2
-      - light.garden_light_3
-      - light.garden_light_4
-      - light.garden_light_5
-      - light.garden_light_6
+      - light.garden_side_lights
+      - light.garden_left_reflectors
+      - light.garden_grill_lights
+      - light.garden_corner_lights
+      - light.garden_back_lights
       - valve.lawn_sprinkler_zone_1
       - valve.lawn_sprinkler_zone_2
       - valve.lawn_sprinkler_zone_3

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -93,6 +93,12 @@ homekit:
 
       # Garden
       - lawn_mower.garden
+      - light.garden_light_1
+      - light.garden_light_2
+      - light.garden_light_3
+      - light.garden_light_4
+      - light.garden_light_5
+      - light.garden_light_6
       - valve.lawn_sprinkler_zone_1
       - valve.lawn_sprinkler_zone_2
       - valve.lawn_sprinkler_zone_3

--- a/packages/misc/config.yaml
+++ b/packages/misc/config.yaml
@@ -6,3 +6,9 @@
 automation: !include_dir_list automations
 script: !include_dir_named scripts
 template: !include_dir_list templates
+
+# Supla cloud — ZAMEL ROW-02 relays (legacy YAML-only integration)
+supla:
+  servers:
+    - server: !secret supla_host
+      access_token: !secret supla_token

--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -10,3 +10,8 @@ twilio_gate_call_payload: "To=+48XXXXXXXXX&From=+1YYYYYYYYYY&Url=http://twimlets
 
 # Garden irrigation — Open-Meteo rain accumulation API (coords zeroed in the template)
 garden_rain_url: "https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&hourly=precipitation&past_days=1&forecast_days=2&timezone=auto"
+
+# Supla cloud (ZAMEL ROW-02 relays) — personal access token from cloud.supla.org
+# Security > Personal Access Tokens; scopes: Channels Read + Action execution
+supla_host: "svrXX.supla.org"
+supla_token: "SUPLA_PERSONAL_ACCESS_TOKEN"


### PR DESCRIPTION
## Summary

- Add legacy `supla:` YAML integration (`packages/misc/config.yaml`) pointing at `svr161.supla.org` via `!secret supla_host` / `!secret supla_token`
- 3× ZAMEL ROW-02 (2-gang WiFi relays) → 6 `switch` entities auto-discovered; ACTION_TRIGGER channels unsupported by legacy integration, ignored
- Placeholders added to `secrets.fake.yaml` (token from cloud.supla.org → Security → Personal Access Tokens; scopes: Channels Read + Action execution)

## Test plan

- [ ] Add `supla_host` + `supla_token` to `/config/secrets.yaml` on the HA box (gitignored — git never ships it; missing secret 500s the whole config reload)
- [ ] Merge, wait for git-pull, call `homeassistant.reload_core_config`
- [ ] Check logs, confirm 6 new `switch.*` entities appear