### PR TITLE
refactor(vacuum): vendor-agnostic entity names for both floors

### DIFF
--- a/dashboards/tablet/appliances.yaml
+++ b/dashboards/tablet/appliances.yaml
@@ -21,8 +21,8 @@ sections:
           - type: vertical-stack
             cards:
               - type: custom:mushroom-vacuum-card
-                entity: vacuum.dreamebot_l10_ultra
-                name: Ground Floor — L10 Ultra
+                entity: vacuum.ground_floor
+                name: Ground Floor Vacuum
                 icon_animation: true
                 commands:
                   - start_pause
@@ -32,9 +32,9 @@ sections:
                 layout: horizontal
 
               - type: custom:mushroom-template-card
-                entity: sensor.dreamebot_l10_ultra_error
+                entity: sensor.ground_floor_error
                 primary: >-
-                  {{ states('sensor.dreamebot_l10_ultra_error') |
+                  {{ states('sensor.ground_floor_error') |
                   replace('_', ' ') | title }}
                 secondary: Error
                 icon: mdi:alert
@@ -43,99 +43,95 @@ sections:
                 visibility:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.dreamebot_l10_ultra_error') not in
+                      {{ states('sensor.ground_floor_error') not in
                       ('no_error', 'unknown', 'unavailable') }}
 
               - type: picture-entity
-                entity: camera.dreamebot_l10_ultra_map
-                camera_image: camera.dreamebot_l10_ultra_map
+                entity: camera.ground_floor_map
+                camera_image: camera.ground_floor_map
                 aspect_ratio: "16:10"
                 show_state: false
                 show_name: false
                 visibility:
                   - condition: state
-                    entity: vacuum.dreamebot_l10_ultra
+                    entity: vacuum.ground_floor
                     state_not: docked
                   - condition: state
-                    entity: sensor.dreamebot_l10_ultra_state
+                    entity: sensor.ground_floor_state
                     state_not: charging_completed
 
               - type: custom:mushroom-chips-card
                 chips:
                   - type: template
-                    entity: select.dreamebot_l10_ultra_suction_level
+                    entity: select.ground_floor_suction_level
                     icon: mdi:fan
                     icon_color: >-
-                      {% if states('select.dreamebot_l10_ultra_suction_level')
+                      {% if states('select.ground_floor_suction_level')
                       == 'quiet' %}disabled{% else %}blue{% endif %}
                     content: >-
-                      {{ states('select.dreamebot_l10_ultra_suction_level') |
+                      {{ states('select.ground_floor_suction_level') |
                       title }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.dreamebot_l10_ultra_suction_level
+                        entity_id: select.ground_floor_suction_level
                   - type: template
-                    entity: select.dreamebot_l10_ultra_cleaning_mode
+                    entity: select.ground_floor_cleaning_mode
                     icon: >-
                       {% set m =
-                      states('select.dreamebot_l10_ultra_cleaning_mode') %}
+                      states('select.ground_floor_cleaning_mode') %}
                       {% if 'mop' in m and 'sweep' in m %}mdi:broom
                       {% elif 'mop' in m %}mdi:water
                       {% else %}mdi:broom{% endif %}
                     icon_color: teal
                     content: >-
-                      {{ states('select.dreamebot_l10_ultra_cleaning_mode') |
+                      {{ states('select.ground_floor_cleaning_mode') |
                       replace('_', ' ') | title }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.dreamebot_l10_ultra_cleaning_mode
+                        entity_id: select.ground_floor_cleaning_mode
                   - type: template
-                    entity: select.dreamebot_l10_ultra_mop_pad_humidity
+                    entity: select.ground_floor_mop_pad_humidity
                     icon: mdi:water-percent
                     icon_color: cyan
                     content: >-
-                      {{ states('select.dreamebot_l10_ultra_mop_pad_humidity')
+                      {{ states('select.ground_floor_mop_pad_humidity')
                       | title }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.dreamebot_l10_ultra_mop_pad_humidity
+                        entity_id: select.ground_floor_mop_pad_humidity
                   - type: template
-                    entity: switch.dreamebot_l10_ultra_dnd
+                    entity: switch.ground_floor_dnd
                     icon: mdi:sleep
                     icon_color: >-
-                      {% if is_state('switch.dreamebot_l10_ultra_dnd', 'on') %}
+                      {% if is_state('switch.ground_floor_dnd', 'on') %}
                       green{% else %}disabled{% endif %}
                     content: DnD
                     tap_action:
                       action: perform-action
                       perform_action: switch.toggle
                       target:
-                        entity_id: switch.dreamebot_l10_ultra_dnd
+                        entity_id: switch.ground_floor_dnd
 
               - type: custom:mushroom-template-card
-                entity: sensor.dreamebot_l10_ultra_filter_left
+                entity: sensor.ground_floor_filter_left
                 primary: Consumables low
                 secondary: >-
                   {% set items = namespace(v=[]) %}
                   {% set vals = {
                     'Main brush':
-                    states('sensor.dreamebot_l10_ultra_main_brush_left'),
+                    states('sensor.ground_floor_main_brush_left'),
                     'Side brush':
-                    states('sensor.dreamebot_l10_ultra_side_brush_left'),
+                    states('sensor.ground_floor_side_brush_left'),
                     'Filter':
-                    states('sensor.dreamebot_l10_ultra_filter_left'),
+                    states('sensor.ground_floor_filter_left'),
                     'Sensor':
-                    states('sensor.dreamebot_l10_ultra_sensor_dirty_left'),
-                    'Mop pad':
-                    states('sensor.dreamebot_l10_ultra_mop_pad_left'),
-                    'Detergent':
-                    states('sensor.dreamebot_l10_ultra_detergent_left')
+                    states('sensor.ground_floor_sensor_dirty_left')
                   } %}
                   {% for name, v in vals.items() %}
                   {% if v not in ('unknown', 'unavailable') and
@@ -153,30 +149,28 @@ sections:
                   - condition: template
                     value_template: >-
                       {% set vals = [
-                        states('sensor.dreamebot_l10_ultra_main_brush_left'),
-                        states('sensor.dreamebot_l10_ultra_side_brush_left'),
-                        states('sensor.dreamebot_l10_ultra_filter_left'),
-                        states('sensor.dreamebot_l10_ultra_sensor_dirty_left'),
-                        states('sensor.dreamebot_l10_ultra_mop_pad_left'),
-                        states('sensor.dreamebot_l10_ultra_detergent_left')
+                        states('sensor.ground_floor_main_brush_left'),
+                        states('sensor.ground_floor_side_brush_left'),
+                        states('sensor.ground_floor_filter_left'),
+                        states('sensor.ground_floor_sensor_dirty_left')
                       ] %}
                       {{ vals | map('float', 100) | select('lt', 20) |
                       list | length > 0 }}
 
               - type: custom:mushroom-template-card
-                entity: sensor.dreamebot_l10_ultra_low_water_warning
+                entity: sensor.ground_floor_low_water_warning
                 primary: Dock attention
                 secondary: >-
                   {% set items = namespace(v=[]) %}
-                  {% if states('sensor.dreamebot_l10_ultra_low_water_warning')
+                  {% if states('sensor.ground_floor_low_water_warning')
                   not in ('no_warning', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Water low'] %}
                   {% endif %}
-                  {% if states('sensor.dreamebot_l10_ultra_mop_pad')
+                  {% if states('sensor.ground_floor_mop_pad')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Mop pad missing'] %}
                   {% endif %}
-                  {% if states('sensor.dreamebot_l10_ultra_dust_collection')
+                  {% if states('sensor.ground_floor_dust_collection')
                   not in ('available', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Dust bag'] %}
                   {% endif %}
@@ -190,25 +184,25 @@ sections:
                   - condition: template
                     value_template: >-
                       {{
-                      states('sensor.dreamebot_l10_ultra_low_water_warning')
+                      states('sensor.ground_floor_low_water_warning')
                       not in ('no_warning', 'unknown', 'unavailable')
                       or
-                      states('sensor.dreamebot_l10_ultra_mop_pad')
+                      states('sensor.ground_floor_mop_pad')
                       not in ('installed', 'unknown', 'unavailable')
                       or
-                      states('sensor.dreamebot_l10_ultra_dust_collection')
+                      states('sensor.ground_floor_dust_collection')
                       not in ('available', 'unknown', 'unavailable') }}
 
               - type: custom:mushroom-chips-card
                 chips:
                   - type: template
-                    entity: sensor.dreamebot_l10_ultra_cleaning_history
+                    entity: sensor.ground_floor_cleaning_history
                     icon: mdi:history
                     icon_color: purple
                     content: >-
                       {%- set ns = namespace(d='', t='', a='') -%}
                       {%- set attrs =
-                      states.sensor.dreamebot_l10_ultra_cleaning_history.attributes
+                      states.sensor.ground_floor_cleaning_history.attributes
                       -%}
                       {%- for k, v in attrs.items() -%}
                       {%- if not ns.t and v is mapping and v.completed is
@@ -225,7 +219,7 @@ sections:
                     tap_action:
                       action: more-info
                   - type: template
-                    entity: sensor.dreamebot_l10_ultra_cleaning_count
+                    entity: sensor.ground_floor_cleaning_count
                     icon: mdi:chart-box
                     icon_color: indigo
                     content: Stats
@@ -234,27 +228,25 @@ sections:
                       browser_mod:
                         service: browser_mod.popup
                         data:
-                          title: L10 Ultra — Lifetime stats
+                          title: Ground Floor Vacuum — Lifetime stats
                           content:
                             type: entities
                             entities:
-                              - sensor.dreamebot_l10_ultra_cleaning_count
-                              - sensor.dreamebot_l10_ultra_total_cleaned_area
-                              - sensor.dreamebot_l10_ultra_total_cleaning_time
-                              - sensor.dreamebot_l10_ultra_first_cleaning_date
-                              - sensor.dreamebot_l10_ultra_firmware_version
-                              - sensor.dreamebot_l10_ultra_main_brush_time_left
-                              - sensor.dreamebot_l10_ultra_side_brush_time_left
-                              - sensor.dreamebot_l10_ultra_filter_time_left
-                              - sensor.dreamebot_l10_ultra_sensor_dirty_time_left
-                              - sensor.dreamebot_l10_ultra_mop_pad_time_left
-                              - sensor.dreamebot_l10_ultra_detergent_time_left
+                              - sensor.ground_floor_cleaning_count
+                              - sensor.ground_floor_total_cleaned_area
+                              - sensor.ground_floor_total_cleaning_time
+                              - sensor.ground_floor_first_cleaning_date
+                              - sensor.ground_floor_firmware_version
+                              - sensor.ground_floor_main_brush_time_left
+                              - sensor.ground_floor_side_brush_time_left
+                              - sensor.ground_floor_filter_time_left
+                              - sensor.ground_floor_sensor_dirty_time_left
 
           - type: vertical-stack
             cards:
               - type: custom:mushroom-vacuum-card
-                entity: vacuum.x40_master
-                name: First Floor — X40 Master
+                entity: vacuum.first_floor
+                name: First Floor Vacuum
                 icon_animation: true
                 commands:
                   - start_pause
@@ -264,9 +256,9 @@ sections:
                 layout: horizontal
 
               - type: custom:mushroom-template-card
-                entity: sensor.x40_master_error
+                entity: sensor.first_floor_error
                 primary: >-
-                  {{ states('sensor.x40_master_error') | replace('_', ' ') |
+                  {{ states('sensor.first_floor_error') | replace('_', ' ') |
                   title }}
                 secondary: Error
                 icon: mdi:alert
@@ -275,93 +267,93 @@ sections:
                 visibility:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.x40_master_error') not in
+                      {{ states('sensor.first_floor_error') not in
                       ('no_error', 'unknown', 'unavailable') }}
 
               - type: picture-entity
-                entity: camera.x40_master_map
-                camera_image: camera.x40_master_map
+                entity: camera.first_floor_map
+                camera_image: camera.first_floor_map
                 aspect_ratio: "16:10"
                 show_state: false
                 show_name: false
                 visibility:
                   - condition: state
-                    entity: vacuum.x40_master
+                    entity: vacuum.first_floor
                     state_not: docked
                   - condition: state
-                    entity: sensor.x40_master_state
+                    entity: sensor.first_floor_state
                     state_not: charging_completed
 
               - type: custom:mushroom-chips-card
                 chips:
                   - type: template
-                    entity: select.x40_master_suction_level
+                    entity: select.first_floor_suction_level
                     icon: mdi:fan
                     icon_color: >-
-                      {% if states('select.x40_master_suction_level') ==
+                      {% if states('select.first_floor_suction_level') ==
                       'quiet' %}disabled{% else %}blue{% endif %}
                     content: >-
-                      {{ states('select.x40_master_suction_level') | title }}
+                      {{ states('select.first_floor_suction_level') | title }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.x40_master_suction_level
+                        entity_id: select.first_floor_suction_level
                   - type: template
-                    entity: select.x40_master_cleaning_mode
+                    entity: select.first_floor_cleaning_mode
                     icon: >-
-                      {% set m = states('select.x40_master_cleaning_mode') %}
+                      {% set m = states('select.first_floor_cleaning_mode') %}
                       {% if 'mop' in m and 'sweep' in m %}mdi:broom
                       {% elif 'mop' in m %}mdi:water
                       {% else %}mdi:broom{% endif %}
                     icon_color: teal
                     content: >-
-                      {{ states('select.x40_master_cleaning_mode') |
+                      {{ states('select.first_floor_cleaning_mode') |
                       replace('_', ' ') | title }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.x40_master_cleaning_mode
+                        entity_id: select.first_floor_cleaning_mode
                   - type: template
-                    entity: select.x40_master_mop_pad_humidity
+                    entity: select.first_floor_mop_pad_humidity
                     icon: mdi:water-percent
                     icon_color: cyan
                     content: >-
-                      {{ states('select.x40_master_mop_pad_humidity') | title
+                      {{ states('select.first_floor_mop_pad_humidity') | title
                       }}
                     tap_action:
                       action: perform-action
                       perform_action: select.select_next
                       target:
-                        entity_id: select.x40_master_mop_pad_humidity
+                        entity_id: select.first_floor_mop_pad_humidity
                   - type: template
-                    entity: switch.x40_master_dnd
+                    entity: switch.first_floor_dnd
                     icon: mdi:sleep
                     icon_color: >-
-                      {% if is_state('switch.x40_master_dnd', 'on') %}green
+                      {% if is_state('switch.first_floor_dnd', 'on') %}green
                       {% else %}disabled{% endif %}
                     content: DnD
                     tap_action:
                       action: perform-action
                       perform_action: switch.toggle
                       target:
-                        entity_id: switch.x40_master_dnd
+                        entity_id: switch.first_floor_dnd
 
               - type: custom:mushroom-template-card
-                entity: sensor.x40_master_filter_left
+                entity: sensor.first_floor_filter_left
                 primary: Consumables low
                 secondary: >-
                   {% set items = namespace(v=[]) %}
                   {% set vals = {
                     'Main brush':
-                    states('sensor.x40_master_main_brush_left'),
+                    states('sensor.first_floor_main_brush_left'),
                     'Side brush':
-                    states('sensor.x40_master_side_brush_left'),
+                    states('sensor.first_floor_side_brush_left'),
                     'Filter':
-                    states('sensor.x40_master_filter_left'),
+                    states('sensor.first_floor_filter_left'),
                     'Sensor':
-                    states('sensor.x40_master_sensor_dirty_left')
+                    states('sensor.first_floor_sensor_dirty_left')
                   } %}
                   {% for name, v in vals.items() %}
                   {% if v not in ('unknown', 'unavailable') and
@@ -379,36 +371,36 @@ sections:
                   - condition: template
                     value_template: >-
                       {% set vals = [
-                        states('sensor.x40_master_main_brush_left'),
-                        states('sensor.x40_master_side_brush_left'),
-                        states('sensor.x40_master_filter_left'),
-                        states('sensor.x40_master_sensor_dirty_left')
+                        states('sensor.first_floor_main_brush_left'),
+                        states('sensor.first_floor_side_brush_left'),
+                        states('sensor.first_floor_filter_left'),
+                        states('sensor.first_floor_sensor_dirty_left')
                       ] %}
                       {{ vals | map('float', 100) | select('lt', 20) |
                       list | length > 0 }}
 
               - type: custom:mushroom-template-card
-                entity: sensor.x40_master_dust_bag_status
+                entity: sensor.first_floor_dust_bag_status
                 primary: Dock attention
                 secondary: >-
                   {% set items = namespace(v=[]) %}
-                  {% if states('sensor.x40_master_dust_bag_status')
+                  {% if states('sensor.first_floor_dust_bag_status')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Dust bag'] %}
                   {% endif %}
-                  {% if states('sensor.x40_master_clean_water_tank_status')
+                  {% if states('sensor.first_floor_clean_water_tank_status')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Clean water tank'] %}
                   {% endif %}
-                  {% if states('sensor.x40_master_dirty_water_tank_status')
+                  {% if states('sensor.first_floor_dirty_water_tank_status')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Dirty water tank'] %}
                   {% endif %}
-                  {% if states('sensor.x40_master_detergent_status')
+                  {% if states('sensor.first_floor_detergent_status')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Detergent'] %}
                   {% endif %}
-                  {% if states('sensor.x40_master_mop_pad')
+                  {% if states('sensor.first_floor_mop_pad')
                   not in ('installed', 'unknown', 'unavailable') %}
                   {% set items.v = items.v + ['Mop pad'] %}
                   {% endif %}
@@ -422,31 +414,31 @@ sections:
                   - condition: template
                     value_template: >-
                       {{
-                      states('sensor.x40_master_dust_bag_status')
+                      states('sensor.first_floor_dust_bag_status')
                       not in ('installed', 'unknown', 'unavailable')
                       or
-                      states('sensor.x40_master_clean_water_tank_status')
+                      states('sensor.first_floor_clean_water_tank_status')
                       not in ('installed', 'unknown', 'unavailable')
                       or
-                      states('sensor.x40_master_dirty_water_tank_status')
+                      states('sensor.first_floor_dirty_water_tank_status')
                       not in ('installed', 'unknown', 'unavailable')
                       or
-                      states('sensor.x40_master_detergent_status')
+                      states('sensor.first_floor_detergent_status')
                       not in ('installed', 'unknown', 'unavailable')
                       or
-                      states('sensor.x40_master_mop_pad')
+                      states('sensor.first_floor_mop_pad')
                       not in ('installed', 'unknown', 'unavailable') }}
 
               - type: custom:mushroom-chips-card
                 chips:
                   - type: template
-                    entity: sensor.x40_master_cleaning_history
+                    entity: sensor.first_floor_cleaning_history
                     icon: mdi:history
                     icon_color: purple
                     content: >-
                       {%- set ns = namespace(d='', t='', a='') -%}
                       {%- set attrs =
-                      states.sensor.x40_master_cleaning_history.attributes
+                      states.sensor.first_floor_cleaning_history.attributes
                       -%}
                       {%- for k, v in attrs.items() -%}
                       {%- if not ns.t and v is mapping and v.completed is
@@ -463,7 +455,7 @@ sections:
                     tap_action:
                       action: more-info
                   - type: template
-                    entity: sensor.x40_master_cleaning_count
+                    entity: sensor.first_floor_cleaning_count
                     icon: mdi:chart-box
                     icon_color: indigo
                     content: Stats
@@ -472,19 +464,19 @@ sections:
                       browser_mod:
                         service: browser_mod.popup
                         data:
-                          title: X40 Master — Lifetime stats
+                          title: First Floor Vacuum — Lifetime stats
                           content:
                             type: entities
                             entities:
-                              - sensor.x40_master_cleaning_count
-                              - sensor.x40_master_total_cleaned_area
-                              - sensor.x40_master_total_cleaning_time
-                              - sensor.x40_master_first_cleaning_date
-                              - sensor.x40_master_firmware_version
-                              - sensor.x40_master_main_brush_time_left
-                              - sensor.x40_master_side_brush_time_left
-                              - sensor.x40_master_filter_time_left
-                              - sensor.x40_master_sensor_dirty_time_left
+                              - sensor.first_floor_cleaning_count
+                              - sensor.first_floor_total_cleaned_area
+                              - sensor.first_floor_total_cleaning_time
+                              - sensor.first_floor_first_cleaning_date
+                              - sensor.first_floor_firmware_version
+                              - sensor.first_floor_main_brush_time_left
+                              - sensor.first_floor_side_brush_time_left
+                              - sensor.first_floor_filter_time_left
+                              - sensor.first_floor_sensor_dirty_time_left
 
       - type: grid
         grid_options:

--- a/dashboards/tablet/home.yaml
+++ b/dashboards/tablet/home.yaml
@@ -588,18 +588,18 @@ sections:
               action: navigate
               navigation_path: /wall-tablet/appliances
           - type: template
-            entity: vacuum.dreamebot_l10_ultra
+            entity: vacuum.ground_floor
             icon: mdi:robot-vacuum
-            icon_color: "{{ 'green' if is_state('vacuum.dreamebot_l10_ultra', 'cleaning') else 'disabled' }}"
-            content: "GF Vac {{ 'cleaning' if is_state('vacuum.dreamebot_l10_ultra', 'cleaning') else 'idle' }}"
+            icon_color: "{{ 'green' if is_state('vacuum.ground_floor', 'cleaning') else 'disabled' }}"
+            content: "GF Vac {{ 'cleaning' if is_state('vacuum.ground_floor', 'cleaning') else 'idle' }}"
             tap_action:
               action: navigate
               navigation_path: /wall-tablet/appliances
           - type: template
-            entity: vacuum.x40_master
+            entity: vacuum.first_floor
             icon: mdi:robot-vacuum
-            icon_color: "{{ 'green' if is_state('vacuum.x40_master', 'cleaning') else 'disabled' }}"
-            content: "1F Vac {{ 'cleaning' if is_state('vacuum.x40_master', 'cleaning') else 'idle' }}"
+            icon_color: "{{ 'green' if is_state('vacuum.first_floor', 'cleaning') else 'disabled' }}"
+            content: "1F Vac {{ 'cleaning' if is_state('vacuum.first_floor', 'cleaning') else 'idle' }}"
             tap_action:
               action: navigate
               navigation_path: /wall-tablet/appliances

--- a/packages/areas/ground-floor/_floor/README.md
+++ b/packages/areas/ground-floor/_floor/README.md
@@ -17,16 +17,16 @@ This is not a room -- it is the umbrella package for the entire ground floor. It
 
 **Turn off all lights** (`script.ground_floor_turn_off_all_lights`) targets `floor_id: ground_floor`, which means it automatically catches every light on the floor -- including any new ones added later -- without needing to maintain a manual entity list.
 
-**Vacuum scripts** send the Dreame L10 Ultra to clean specific segments at suction level 3 with mopping (water volume 3):
+**Vacuum scripts** send the ground floor vacuum (`vacuum.ground_floor`) to clean specific segments at suction level 3 with mopping (water volume 3):
 
-- `script.vacuum_clean_kitchen` -- segment 2 (kitchen)
-- `script.vacuum_clean_mudroom` -- segment 8 (mudroom)
+- `script.vacuum_clean_kitchen` -- segment 4 (kitchen)
+- `script.vacuum_clean_mudroom` -- segment 5 (mudroom)
 
 ## Gotchas
 
 - The light status sensor uses `floor_areas('ground_floor')` to auto-discover lights, so it picks up new entities as soon as they are assigned to a ground-floor area. The ignored-lights list, however, is hardcoded -- if you add more ambient lights that should be excluded, update `lights_status.yaml` manually.
 - The "turn off all lights" script also relies on `floor_id`, not the light group. It will turn off lights the group does not contain (e.g. toilet, vestibule). This is intentional.
-- Vacuum segment IDs (`2` for kitchen, `8` for mudroom) are mapped inside the Dreame vacuum's firmware. If you re-map rooms in the Dreame app, these IDs will change silently and the scripts will clean the wrong areas.
+- Vacuum segment IDs (`4` for kitchen, `5` for mudroom) are mapped inside the vacuum's firmware. If you re-map rooms in the vacuum app, these IDs will change silently and the scripts will clean the wrong areas. Entity IDs are vendor-agnostic (`vacuum.ground_floor`); the physical device is currently a Dreame r5039a.
 - `binary_sensor.common_area_presence` appears in the presence aggregation but does not correspond to a dedicated area package -- it likely comes from a shared/presence package or a Zigbee2MQTT group.
 
 ## Entities
@@ -45,7 +45,7 @@ This is not a room -- it is the umbrella package for the entire ground floor. It
 - `binary_sensor.vestibule_presence` -- vestibule presence
 - `binary_sensor.toilet_presence` -- toilet presence sensor
 - `binary_sensor.garden_presence` -- garden/terrace presence
-- `vacuum.dreamebot_l10_ultra` -- Dreame L10 Ultra robot vacuum (via `dreame_vacuum.vacuum_clean_segment`)
+- `vacuum.ground_floor` -- ground floor robot vacuum (via `dreame_vacuum.vacuum_clean_segment`)
 - `light.kitchen_led`, `light.kitchen_main`, `light.kitchen_island` -- kitchen package
 - `light.dining_room` -- dining room light
 - `light.ground_floor_painting_walls` -- accent wall lights

--- a/packages/areas/ground-floor/_floor/scripts/vacuum_clean_kitchen.yaml
+++ b/packages/areas/ground-floor/_floor/scripts/vacuum_clean_kitchen.yaml
@@ -1,12 +1,12 @@
 ---
 alias: vacuum_clean_kitchen
-description: "Clean kitchen with Dreame L10 Ultra"
+description: "Clean kitchen with the ground floor vacuum"
 icon: mdi:robot-vacuum
 sequence:
   - action: dreame_vacuum.vacuum_clean_segment
     data:
-      entity_id: vacuum.dreamebot_l10_ultra
-      segments: 2
+      entity_id: vacuum.ground_floor
+      segments: 4
       repeats: 1
       suction_level: 3
       water_volume: 3

--- a/packages/areas/ground-floor/_floor/scripts/vacuum_clean_mudroom.yaml
+++ b/packages/areas/ground-floor/_floor/scripts/vacuum_clean_mudroom.yaml
@@ -1,12 +1,12 @@
 ---
 alias: vacuum_clean_mudroom
-description: "Clean mudroom with Dreame L10 Ultra"
+description: "Clean mudroom with the ground floor vacuum"
 icon: mdi:robot-vacuum
 sequence:
   - action: dreame_vacuum.vacuum_clean_segment
     data:
-      entity_id: vacuum.dreamebot_l10_ultra
-      segments: 8
+      entity_id: vacuum.ground_floor
+      segments: 5
       repeats: 1
       suction_level: 3
       water_volume: 3

--- a/packages/bootstrap/config.yaml
+++ b/packages/bootstrap/config.yaml
@@ -11,7 +11,7 @@ recorder:
       - binary_sensor.browser_mod_*
       - media_player.browser_mod_*
       - light.browser_mod_*
-      - switch.dreamebot_*
+      - switch.ground_floor_*
       - switch.first_floor_*
     entities:
       - switch.zigbee2mqtt_bridge_permit_join

--- a/packages/homekit/config.yaml
+++ b/packages/homekit/config.yaml
@@ -72,7 +72,7 @@ homekit:
       - light.ensuite_bathroom_leds
       - light.ensuite_bathroom_main
 
-      - vacuum.l10_ultra
+      - vacuum.ground_floor
 
       # Cameras
       - camera.porch
@@ -205,7 +205,7 @@ homekit:
     light.ensuite_bathroom_main:
       name: Main
 
-    vacuum.l10_ultra:
+    vacuum.ground_floor:
       name: Vacuum
 
     camera.porch:

--- a/packages/misc/automations/misc_vacuum_reminder_first_floor.yaml
+++ b/packages/misc/automations/misc_vacuum_reminder_first_floor.yaml
@@ -20,7 +20,7 @@ condition:
   - condition: template
     value_template: >-
       {{
-        (now() - states('sensor.x40_master_cleaning_history')
+        (now() - states('sensor.first_floor_cleaning_history')
           | as_datetime | default(now()))
         > timedelta(days=3)
       }}
@@ -37,7 +37,7 @@ action:
       title: "Vacuum Reminder"
       message: >-
         First floor vacuum hasn't cleaned since
-        {{ states('sensor.x40_master_cleaning_history')
+        {{ states('sensor.first_floor_cleaning_history')
            | as_datetime | as_local
            | string | truncate(16, true, '') }}.
         Consider starting a clean while you're away.
@@ -46,7 +46,7 @@ action:
       title: "Vacuum Reminder"
       message: >-
         First floor vacuum hasn't cleaned since
-        {{ states('sensor.x40_master_cleaning_history')
+        {{ states('sensor.first_floor_cleaning_history')
            | as_datetime | as_local
            | string | truncate(16, true, '') }}.
         Consider starting a clean while you're away.

--- a/packages/misc/automations/misc_vacuum_reminder_ground_floor.yaml
+++ b/packages/misc/automations/misc_vacuum_reminder_ground_floor.yaml
@@ -20,7 +20,7 @@ condition:
   - condition: template
     value_template: >-
       {{
-        (now() - states('sensor.dreamebot_l10_ultra_cleaning_history')
+        (now() - states('sensor.ground_floor_cleaning_history')
           | as_datetime | default(now()))
         > timedelta(days=3)
       }}
@@ -37,7 +37,7 @@ action:
       title: "Vacuum Reminder"
       message: >-
         Ground floor vacuum hasn't cleaned since
-        {{ states('sensor.dreamebot_l10_ultra_cleaning_history')
+        {{ states('sensor.ground_floor_cleaning_history')
            | as_datetime | as_local
            | string | truncate(16, true, '') }}.
         Consider starting a clean while you're away.
@@ -46,7 +46,7 @@ action:
       title: "Vacuum Reminder"
       message: >-
         Ground floor vacuum hasn't cleaned since
-        {{ states('sensor.dreamebot_l10_ultra_cleaning_history')
+        {{ states('sensor.ground_floor_cleaning_history')
            | as_datetime | as_local
            | string | truncate(16, true, '') }}.
         Consider starting a clean while you're away.


### PR DESCRIPTION
## Summary
Old ground-floor Dreame L10 Ultra replaced by new r5039a. Unify all vacuum entity naming to be vendor/product agnostic across both floors.

## Ground floor (new r5039a)
- New device paired with config-entry title "Ground Floor" -> entities already `vacuum.ground_floor` / `*_ground_floor` (agnostic).
- Repointed dead `dreamebot_l10_ultra` / `l10_ultra` refs across dashboards, reminder automation, HomeKit, recorder glob.
- Fixed clean-segment scripts to the r5039a map: **kitchen 2->4, mudroom 8->5**.
- Dropped detergent-life / mop-pad-life cells (r5039a reports status only, no % wear).

## First floor (existing X40 Master, r2465a)
- Renamed **all 224 live registry entity IDs** `x40_master_*` -> `first_floor_*` + config-entry title -> "First Floor" (applied via WS registry API — already live).
- Repointed dashboard + reminder refs.

## UI
- Dropped hardcoded "L10 Ultra"/"X40 Master" labels for floor-based names.
- Cleaned messy vacuum `friendly_name`s in the registry.

## ⚠️ Deploy note
Registry rename is already live on HA. Config on `main` still references OLD IDs until this merges — **merge promptly** to avoid the split state, then reload core config + hard-refresh the tablet.