### PR TITLE
feat(garden): watchdog self-heals sprinkler zombie via relay power-cycle

### DIFF
--- a/packages/areas/outdoor/garden/README.md
+++ b/packages/areas/outdoor/garden/README.md
@@ -149,6 +149,7 @@ The dashboards (tablet Outdoor + phone Garden room) carry a **Run Lawn Now** blo
 - **Valves can't run simultaneously** — the Tuya controller doesn't support it. The 06:15 vertical check and 06:30 drip guarantee both wait (up to 90 min) for valves closed + scripts idle before opening anything.
 - **Auto-off reads duration at valve-open time** — changing mode mid-run won't affect an already-running valve.
 - **Zones 5-8 on the Tuya controller are unused** — hardware supports 4 zones.
+- **The controller self-heals when it wedges** — the offline watchdog first reloads the tuya_local entry (HA-side wedge), then cuts controller power for 10s via `switch.sprinkler_relay` (Zigbee plug on the controller's feed — true device zombie) and reloads again. A phone alert now means both already failed and someone must look at the hardware. The relay must stay ON in normal operation; the watchdog never exits with it off. See knowledge **tuya-local-sprinkler-zombie**.
 - **Max-open watchdog caps are per-valve** (lawn 55 min, vertical 155 min, drip 60 min) — sized above each valve's longest legitimate open (vertical slider max 150 min). A single shared 30-min cap used to force-close every 45-min drip run and hot-day deep lawn run mid-water. The spurious-close guard's hold timeout (160 min) must also sit above the longest run — it safety-closes on timeout.
 - **The `docs/irrigation.svg` animation still shows the 3-zone lawn layout** — regenerate via `/ha-automation-animations` when the new site plan is drawn.
 - **`schedule_7day` sizes each day's heat off ITS OWN forecast** — the dashboard table reads `sensor.garden_forecast_today`'s per-day `forecast_7day`. It re-evaluates at fire time (04:00), so a cool-down tonight changes tomorrow's real run; days past the ~6-day forecast horizon fall back to Mild.
@@ -232,7 +233,7 @@ The dashboards (tablet Outdoor + phone Garden room) carry a **Run Lawn Now** blo
 | `automations/garden_irrigation_cleanup.yaml` | Closes the ending script's own valves on script end (skips when parent full irrigation running) |
 | `automations/garden_valve_startup_close.yaml` | Force-closes all valves + clears the on-demand flag on HA boot |
 | `automations/garden_valve_max_open_watchdog.yaml` | Every 5 min, force-closes any valve open longer than its per-valve cap (lawn 55m / vertical 155m / drip 60m) |
-| `automations/garden_valve_offline_watchdog.yaml` | Notifies when sprinkler valves go offline |
+| `automations/garden_valve_offline_watchdog.yaml` | Valves offline >10 min: reloads tuya_local entry, then power-cycles the controller via `switch.sprinkler_relay`, notifies only if both fail |
 | `automations/garden_valve_offline_alert_reset.yaml` | Clears the offline-alerted latch at midnight or on valve recovery |
 | `scripts/garden_lawn_irrigation.yaml` | Sequential zones 1→2 |
 | `scripts/garden_drip_irrigation.yaml` | Drip valve with wait-for-close |

--- a/packages/areas/outdoor/garden/automations/garden_valve_offline_watchdog.yaml
+++ b/packages/areas/outdoor/garden/automations/garden_valve_offline_watchdog.yaml
@@ -11,21 +11,24 @@ description: >
   before watering is expected.
 
   Every 10 min: if any garden valve has been unavailable for the whole window,
-  first try to self-heal by reloading the tuya_local config entry, and only
-  bother a human if that fails. Two distinct wedges look identical from here:
-  an HA-side one (the entry's local connection died while the device is fine),
-  which a reload fixes; and a true device zombie (answers TCP, serves garbage on
-  the local handshake), which only a power-cycle fixes. Reloading first means
-  the recoverable case never reaches the phone, and the notification that does
-  arrive is honest — a reload was already tried and did not help. A latch
+  first try to self-heal by reloading the tuya_local config entry, then by
+  power-cycling the controller via switch.sprinkler_relay (Zigbee plug feeding
+  it — independent of the controller's Wi-Fi), and only bother a human if both
+  fail. Two distinct wedges look identical from here: an HA-side one (the
+  entry's local connection died while the device is fine), which a reload
+  fixes; and a true device zombie (answers TCP, serves garbage on the local
+  handshake), which only a power-cycle fixes. Trying both means neither
+  recoverable case reaches the phone, and the notification that does arrive is
+  honest — reload and power-cycle were already tried and did not help. A latch
   (input_boolean.garden_valve_offline_alerted) suppresses repeats — it is set
   here and cleared on valve recovery or at midnight by
   garden_valve_offline_alert_reset, so the alert fires at most once per day.
 id: garden-valve-offline-watchdog
 
-# single (not restart): the sequence reloads, then waits up to 90s for the
-# valves to come back. A 10-min re-fire must not abort that wait and re-reload
-# mid-recovery. max_exceeded silent because a skipped overlap is the intent.
+# single (not restart): the sequence reloads, power-cycles, and waits for the
+# valves to come back (worst case ~5 min). A 10-min re-fire must not abort that
+# wait and re-reload mid-recovery. max_exceeded silent because a skipped
+# overlap is the intent.
 mode: single
 max_exceeded: silent
 
@@ -107,17 +110,89 @@ action:
             recovered them. No power-cycle needed.
       - stop: Recovered by config entry reload
 
-  # --- Attempt 1 failed: real device zombie, needs hands on the plug ---------
+  # --- Attempt 2: power-cycle the controller via its Zigbee feed relay -------
+  # The true zombie (answers TCP, garbage on the local handshake) only clears
+  # with a power interruption. switch.sprinkler_relay is the Zigbee plug
+  # feeding the controller, so it works even when the controller's Wi-Fi side
+  # is wedged. Skipped (straight to the human) if the relay itself is
+  # unreachable — cutting power we can't restore would turn a soft outage into
+  # a hard one.
+  - if:
+      - condition: template
+        value_template: >
+          {{ states('switch.sprinkler_relay')
+             not in ['unavailable', 'unknown'] }}
+    then:
+      - alias: Cut controller power for 10s
+        action: switch.turn_off
+        target:
+          entity_id: switch.sprinkler_relay
+      - delay: "00:00:10"
+      - alias: Restore controller power
+        action: switch.turn_on
+        target:
+          entity_id: switch.sprinkler_relay
+      # Belt and braces: if the Zigbee command was dropped, re-assert ON once.
+      # Never leave this branch with the relay off.
+      - wait_template: "{{ is_state('switch.sprinkler_relay', 'on') }}"
+        timeout: "00:00:15"
+        continue_on_timeout: true
+      - if:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: switch.sprinkler_relay
+                state: "on"
+        then:
+          - action: switch.turn_on
+            target:
+              entity_id: switch.sprinkler_relay
+      - alias: Give the controller time to boot and rejoin Wi-Fi
+        delay: "00:01:30"
+      # setup_retry backs off between attempts, so force a retry now instead
+      # of waiting out the backoff window.
+      - alias: Reload the entry again now that the device rebooted
+        action: homeassistant.reload_config_entry
+        data:
+          entry_id: >
+            {{ config_entry_id('valve.lawn_sprinkler_zone_1') }}
+      - alias: Wait for the valves to republish after the power-cycle
+        wait_template: >
+          {{ expand(garden_valves)
+               | rejectattr('state', 'eq', 'unavailable')
+               | list | count > 0 }}
+        timeout: "00:01:30"
+        continue_on_timeout: true
+
+  # Power-cycle worked — log the save and stop. Latch stays SET for the same
+  # anti-flap reason as attempt 1; garden_valve_offline_alert_reset owns
+  # clearing it.
+  - if:
+      - condition: template
+        value_template: >
+          {{ expand(garden_valves)
+               | rejectattr('state', 'eq', 'unavailable')
+               | list | count > 0 }}
+    then:
+      - action: logbook.log
+        data:
+          name: Garden Valve Watchdog
+          message: >
+            Valves were unavailable >10 min; entry reload did not help, but a
+            power-cycle via switch.sprinkler_relay recovered them.
+      - stop: Recovered by relay power-cycle
+
+  # --- Both attempts failed: needs a human ----------------------------------
   - action: persistent_notification.create
     data:
       notification_id: garden_valve_offline_watchdog
       title: Sprinkler controller offline
       message: >
-        One or more garden valves have been unavailable for >10 min and a
-        tuya_local entry reload did not bring them back. The Tuya "Sprinker"
-        controller is wedged (online but not answering local control) — this
-        needs a power-cycle: unplug ~10s, replug, ~1 min to rejoin Wi-Fi.
-        Irrigation will not run until it is back.
+        One or more garden valves have been unavailable for >10 min; a
+        tuya_local entry reload and an automatic power-cycle via
+        switch.sprinkler_relay both failed to bring them back. Check the
+        controller and the relay plug in person. Irrigation will not run
+        until it is back.
   # Push only during waking hours — power-cycling the controller is a daytime
   # job and irrigation runs on a fixed schedule, so nothing is lost by holding
   # the push until morning. The persistent_notification fires at any hour.
@@ -130,13 +205,14 @@ action:
         data:
           title: Sprinkler controller offline
           message: >
-            Garden valves unavailable >10 min, auto-reload failed — power-cycle
-            the Sprinker controller. Irrigation won't run until recovered.
+            Garden valves unavailable >10 min, auto-reload and relay
+            power-cycle both failed — check the Sprinker controller in
+            person. Irrigation won't run until recovered.
           data:
             tag: garden-valve-offline
   - action: logbook.log
     data:
       name: Garden Valve Watchdog
       message: >
-        Garden valves unavailable >10 min and an entry reload failed — Sprinker
-        controller wedged, power-cycle to recover.
+        Garden valves unavailable >10 min; entry reload and relay power-cycle
+        both failed — Sprinker controller needs in-person attention.

--- a/packages/misc/automations/misc_dyson_fan_relay_daily_cycle.yaml
+++ b/packages/misc/automations/misc_dyson_fan_relay_daily_cycle.yaml
@@ -1,0 +1,60 @@
+---
+# Cross-Area Automation: Dyson Fan Relay Daily Power-Cycle
+# The Dyson fan in the attic office is fed by a Zigbee relay
+# (switch.dyson_fan_relay). A daily power interruption at 18:00 resets the
+# fan's own controller. Runs unconditionally — the relay always ends ON, so
+# an already-off relay is switched on by this automation.
+
+alias: Misc - Dyson Fan Relay Daily Power-Cycle
+description: >
+  At 18:00 every day, cut power to the Dyson fan relay for 5 seconds and
+  restore it. The relay must never be left off: if the ON command is dropped
+  on the Zigbee mesh, it is re-asserted once before the automation exits.
+id: 6f2c14b8-3d5a-4e17-9c02-5a7f1e8b4d63
+
+# single: a re-fire mid-cycle must not abort the 5s gap and leave the relay
+# off. There is only one time trigger, so an overlap is not expected — silent
+# because skipping a redundant overlap is the intent.
+mode: single
+max_exceeded: silent
+
+triggers:
+  - trigger: time
+    at: "18:00:00"
+
+conditions:
+  # Skip when the relay is unreachable — cutting power we cannot restore turns
+  # a soft outage into a fan that stays dead until someone notices.
+  - condition: template
+    value_template: >
+      {{ states('switch.dyson_fan_relay') not in ['unavailable', 'unknown'] }}
+
+actions:
+  - alias: Cut fan power
+    action: switch.turn_off
+    target:
+      entity_id: switch.dyson_fan_relay
+
+  - delay: "00:00:05"
+
+  - alias: Restore fan power
+    action: switch.turn_on
+    target:
+      entity_id: switch.dyson_fan_relay
+
+  # Belt and braces: if the Zigbee command was dropped, re-assert ON once.
+  # Never exit this automation with the relay off.
+  - wait_template: "{{ is_state('switch.dyson_fan_relay', 'on') }}"
+    timeout: "00:00:15"
+    continue_on_timeout: true
+
+  - if:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: switch.dyson_fan_relay
+            state: "on"
+    then:
+      - action: switch.turn_on
+        target:
+          entity_id: switch.dyson_fan_relay


### PR DESCRIPTION
Uses the new `switch.sprinkler_relay` (Zigbee2MQTT plug feeding the Sprinker controller).

Watchdog escalation now: tuya_local entry reload → 10s power-cut via relay → boot wait 90s → entry reload (forces retry past setup_retry backoff) → wait → only then persistent notification + phone push. Guards: relay step skipped when relay unavailable; ON re-asserted if the Zigbee command drops.

Stacked on `feature/attic-base-automations` (box is live on it).

https://claude.ai/code/session_01UskfWxqjWfDWwUUafKzRkp